### PR TITLE
run k8s config on schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,4 +75,4 @@ k8s_deploy:
   - kubectl apply -f k8s/yaml/ -n $NAMESPACE 
   rules:
   - if: '$CI_COMMIT_BRANCH == "master"'
-  - if: $CI_PIPELINE_SOURCE == "schedule"
+  - if: '$CI_PIPELINE_SOURCE == "schedule"'


### PR DESCRIPTION
When we change a variable in gitlab CI/CD, it would be nice to have an easy way to apply those changes via the gitlab UI (since the vars are there) rather than manually update and apply the relevant YAML. I figure this way, we can run the scheduled job on demand.

Not sure if there is a better option, e.g. a gitlab trigger/rule for 'when CI/CD vars are updated'? What do you think?