### PR TITLE
increase number of cards on dashboard and fix text wrapping of sidebar

### DIFF
--- a/dashboard/src/t5gweb/static/style.css
+++ b/dashboard/src/t5gweb/static/style.css
@@ -137,3 +137,6 @@ ul.highlight:hover {
   background-color: #eee;
 }
 
+.link-dark {
+  overflow-wrap: anywhere;
+}

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -71,7 +71,7 @@ def get_new_comments():
             exit (1)
     board = libtelco5g.get_board_id(conn, cfg['board'])
     sprint = libtelco5g.get_latest_sprint(conn, board.id, cfg['sprintname'])
-    cards = conn.search_issues("sprint=" + str(sprint.id) + " AND updated >= '-7d'")
+    cards = conn.search_issues("sprint=" + str(sprint.id) + " AND updated >= '-7d'", maxResults=1000)
 
     token=libtelco5g.get_token(cfg['offline_token'])
 
@@ -135,7 +135,7 @@ def get_cnv():
 
     board = libtelco5g.get_board_id(conn, cfg['board'])
     sprint = libtelco5g.get_latest_sprint(conn, board.id, cfg['sprintname'])
-    cards = conn.search_issues("sprint=" + str(sprint.id) + " AND updated >= '-7d'")
+    cards = conn.search_issues("sprint=" + str(sprint.id) + " AND updated >= '-7d'", maxResults=1000)
 
     token=libtelco5g.get_token(cfg['offline_token'])
 


### PR DESCRIPTION
- Increased amount of cards displayed on dashboard. Previously, some cards weren't being displayed on dashboard because `search_issues()` only returns 50 cards by default.
- Some entries on the sidebar were running into the content of the updates, so the wrapping of the text was changed to break anywhere