### PR TITLE
Adding CNV cases to get_new_comments()

### DIFF
--- a/bin/libtelco5g.py
+++ b/bin/libtelco5g.py
@@ -530,7 +530,7 @@ def get_cases_json(token, query, fields, num_cases=1000, exclude_closed=True):
   return cases_json
 
 
-def get_cases(cases_json):
+def get_cases(cases_json, include_tags=False):
   cases = {}
   for case in cases_json:
     #print(case)
@@ -547,6 +547,10 @@ def get_cases(cases_json):
     # Sometimes there is no BZ attached to the case
     if "case_bugzillaNumber" in case:
         cases[case["case_number"]]["bug"] = case["case_bugzillaNumber"]
+
+    # Sometimes there is no tag attached to the case
+    if "case_tags" in case and include_tags:
+        cases[case["case_number"]]["tags"] = case["case_tags"]
 
   return cases
 

--- a/dashboard/src/t5gweb/templates/ui/updates.html
+++ b/dashboard/src/t5gweb/templates/ui/updates.html
@@ -37,7 +37,7 @@
                      </div>
                   </li> 
                   {% endfor %}   
-                  {% for cnv in new_cnv %}  
+                  <!-- {% for cnv in new_cnv %}  
                      <button class="btn btn-toggle align-items-center rounded collapsed" data-bs-toggle="collapse" data-bs-target="#{{cnv}}-collapse" aria-expanded="false">
                         {{cnv}}
                      </button>
@@ -51,7 +51,7 @@
                         </ul>
                      </div>
                   </li> 
-                  {% endfor %}
+                  {% endfor %} -->
                </ul>
             </div>
          </div>
@@ -92,7 +92,7 @@
                   {% endif %}
                   </ul>
                {% endfor %}
-               {% for cnv in new_cnv %}
+               <!-- {% for cnv in new_cnv %}
                   <ul>
                   <li><span class = "account">{{ cnv }}</span></li>
                   {% if new_cnv[cnv] != "No Updates" %}
@@ -114,7 +114,6 @@
                                        <li>{{ comment }}</li>
                                     </ul>
                                  {% endfor %}
-                                 <!-- <hr class="divide"> -->
                                  </ul>
                               {% endfor %}
                            </ul>
@@ -126,7 +125,7 @@
                      </ul>
                   {% endif %}
                   </ul>
-               {% endfor %}
+               {% endfor %} -->
             </div>
             <script>
                new Vue({

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -8,7 +8,7 @@ from . import cache
 from t5gweb.t5gweb import (
     get_new_cases,
     get_new_comments,
-    get_cnv,
+    # get_cnv,
     plots
 )
 
@@ -38,6 +38,6 @@ def refresh():
 def updates():
     """Retrieves summary data and creates Chart.JS plot"""
     new_comments = get_new_comments()
-    new_cnv = get_cnv()
+    # new_cnv = get_cnv()
     now = datetime.datetime.utcnow()
-    return render_template('ui/updates.html', now=now, new_comments=new_comments, new_cnv=new_cnv)
+    return render_template('ui/updates.html', now=now, new_comments=new_comments)#, new_cnv=new_cnv)


### PR DESCRIPTION
- Added include_tags argument to get_cases()
- Added CNV cases to get_new_cases() to reduce loading times. When I run it locally the loading time for the dashboard is halved after these changes.
- Changed query in get_new_cases() to grab cnv cases in addition to webscale and shift_telco5g
- Commented out unneeded code, will remove once we know that it's working without them