### PR TITLE
converting from Jira user & password to PAT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,18 +53,15 @@ k8s_deploy:
   stage: deploy
   before_script:
   #Shift_Telco
-  - sed -i 's/Jira_User/'"$Jira_User"'/g' k8s/yaml/config-map.yml
   - sed -i 's/Jira_Pass/'"$Jira_Pass"'/g' k8s/yaml/config-map.yml
   - echo k8s/yaml/config-map.yml | awk -i inplace -v srch="Offline_token" -v repl="$Offline_token" '{ sub(srch,repl,$0); print $0 }' k8s/yaml/config-map.yml
   - echo k8s/yaml/config-map.yml | awk -i inplace -v srch="Slack_token" -v repl="$Slack_token" '{ sub(srch,repl,$0); print $0 }' k8s/yaml/config-map.yml
   - echo k8s/yaml/config-map.yml | awk -i inplace -v srch="Slack_channel" -v repl="$Slack_channel" '{ sub(srch,repl,$0); print $0 }' k8s/yaml/config-map.yml
   - echo k8s/yaml/config-map.yml | awk -i inplace -v srch="Team" -v repl="$Team" '{ sub(srch,repl,$0); print $0 }' k8s/yaml/config-map.yml
   #CNV
-  - sed -i 's/Jira_User/'"$Jira_User"'/g' k8s/yaml/config-map-cnv.yml
   - sed -i 's/Jira_Pass/'"$Jira_Pass"'/g' k8s/yaml/config-map-cnv.yml
   - echo k8s/yaml/config-map-cnv.yml | awk -i inplace -v srch="Offline_token" -v repl="$Offline_token" '{ sub(srch,repl,$0); print $0 }' k8s/yaml/config-map-cnv.yml
   #Dashboard
-  - sed -i 's/Jira_User/'"$Jira_User"'/g' dashboard/yaml/04_t5gweb-app-deployment.yml
   - sed -i 's/Jira_Pass/'"$Jira_Pass"'/g' dashboard/yaml/04_t5gweb-app-deployment.yml
   - echo dashboard/yaml/04_t5gweb-app-deployment.yml | awk -i inplace -v srch="Offline_token" -v repl="$Offline_token" '{ sub(srch,repl,$0); print $0 }' dashboard/yaml/04_t5gweb-app-deployment.yml
   - echo dashboard/yaml/04_t5gweb-app-deployment.yml | awk -i inplace -v srch="Accounts" -v repl="$Accounts" '{ sub(srch,repl,$0); print $0 }' dashboard/yaml/04_t5gweb-app-deployment.yml

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Link to script usage: [telco5g-jira.py readme](https://github.com/RHsyseng/t5g-f
 This project has a CI that is triggered on every push. 
 
 Note: There are some environment variables which needed to be set in the GitLab:
-Jira_User & Jira_Pass - The Jira details to Connect to the board
+Jira_Pass - The Jira details to Connect to the board
 OCP_USER & OCP_PASS - Connection detilas to our LAB OCP 
 Offline_token - API token to connect to customer protal 

--- a/bin/closed-case-but-open-issue.py
+++ b/bin/closed-case-but-open-issue.py
@@ -51,17 +51,16 @@ def main():
     else:
         cfg['debug'] = False
 
-    # Check for the password
+    # Check for the Jira PAT
     if len(cfg['password']) <= 0:
         if sys.stdin.isatty():
-            cfg['password'] = getpass.getpass('Enter the Jira password: ')
+            cfg['password'] = getpass.getpass('Enter the Jira PAT: ')
         else:
             cfg['password'] = sys.stdin.readline().rstrip()
 
     print('Connecting to Jira instance')
-    options = { 'server': cfg['server'] }
-
-    conn = libtelco5g.jira_connection(options, cfg)
+    
+    conn = libtelco5g.jira_connection(cfg)
     
     if cfg['debug']:
         print('\nDEBUG: Connection')

--- a/bin/jira-duplicates.py
+++ b/bin/jira-duplicates.py
@@ -46,17 +46,16 @@ def main():
     else:
         cfg['debug'] = False
 
-    # Check for the password
+    # Check for the Jira PAT
     if len(cfg['password']) <= 0:
         if sys.stdin.isatty():
-            cfg['password'] = getpass.getpass('Enter the Jira password: ')
+            cfg['password'] = getpass.getpass('Enter the Jira PAT: ')
         else:
             cfg['password'] = sys.stdin.readline().rstrip()
 
     print('Connecting to Jira instance')
-    options = { 'server': cfg['server'] }
 
-    conn = libtelco5g.jira_connection(options, cfg)
+    conn = libtelco5g.jira_connection(cfg)
     
     if cfg['debug']:
         print('\nDEBUG: Connection')

--- a/bin/jira-summary.py
+++ b/bin/jira-summary.py
@@ -46,17 +46,16 @@ def main():
     else:
         cfg['debug'] = False
 
-    # Check for the password
+    # Check for the Jira PAT
     if len(cfg['password']) <= 0:
         if sys.stdin.isatty():
-            cfg['password'] = getpass.getpass('Enter the Jira password: ')
+            cfg['password'] = getpass.getpass('Enter the Jira PAT: ')
         else:
             cfg['password'] = sys.stdin.readline().rstrip()
 
     print('Connecting to Jira instance')
-    options = { 'server': cfg['server'] }
 
-    conn = libtelco5g.jira_connection(options, cfg)
+    conn = libtelco5g.jira_connection(cfg)
     
     if cfg['debug']:
         print('\nDEBUG: Connection')

--- a/bin/libtelco5g.py
+++ b/bin/libtelco5g.py
@@ -32,12 +32,14 @@ portal2jira_sevs = {
 }
 
 
-def jira_connection(options, cfg):
+def jira_connection(cfg):
     try:
-        conn = jira.JIRA(options, basic_auth=(cfg['user'], cfg['password']))
+        headers = jira.JIRA.DEFAULT_OPTIONS["headers"].copy()
+        headers["Authorization"] = f"Bearer {cfg['password']}"
+        conn=jira.JIRA(server=cfg['server'], options={"headers": headers})
     except jira.exceptions as e:
         if e.status_code ==401:
-            print("Login to JIRA failed. Check your username and password")
+            print("Login to JIRA failed. Check your credentials")
             exit (1)
         if e.status_code == 503:
             print("JIRA is down.")
@@ -446,7 +448,7 @@ def set_defaults():
     defaults['smtp']        = 'smtp.corp.redhat.com'
     defaults['from']        = 't5g_jira@redhat.com'
     defaults['to']          = ''
-    defaults['alert_to'] = 'dcritch@redhat.com'
+    defaults['alert_to']    = 'dcritch@redhat.com'
     defaults['subject']     = 'New Card(s) Have Been Created to Track Telco5G Issues'
     defaults['sprintname']  = 'T5GFE' #Previous Sprintname: 'Labs and Field Sprint' 
     defaults['server']      = 'https://issues.redhat.com'
@@ -458,12 +460,11 @@ def set_defaults():
     defaults['labels']      = 'field, no-qe, no-doc'
     defaults['priority']    = 'High'
     defaults['points']      = 3
-    defaults['user']        = os.getenv('user', getpass.getuser())
     defaults['password']    = ''
     defaults['card_action'] = 'none'
     defaults['debug']       = 'False'
     defaults['sheet_id']    = '1I-Sw3qBCDv3jHon7J_H3xgPU2-mJ8c-9E1h5DeVZUbk'
-    defaults['range_name']       = 'webscale - knieco field eng!A2:J'
+    defaults['range_name']  = 'webscale - knieco field eng!A2:J'
     #defaults['team']        = [
     #    {"user": "dcritch", "name": "David Critch"},
     #    {"user": "rhn-support-pibanezr", "name": "Pedro Ibanez Requena"},

--- a/bin/sprint-summary.py
+++ b/bin/sprint-summary.py
@@ -49,17 +49,16 @@ def main():
     
     cfg['team'] = json.loads(cfg['team'])
 
-    # Check for the password
+    # Check for the Jira PAT
     if len(cfg['password']) <= 0:
         if sys.stdin.isatty():
-            cfg['password'] = getpass.getpass('Enter the Jira password: ')
+            cfg['password'] = getpass.getpass('Enter the Jira PAT: ')
         else:
             cfg['password'] = sys.stdin.readline().rstrip()
 
     print('Connecting to Jira instance')
-    options = { 'server': cfg['server'] }
 
-    conn = libtelco5g.jira_connection(options, cfg)
+    conn = libtelco5g.jira_connection(cfg)
     
     if cfg['debug']:
         print('\nDEBUG: Connection')

--- a/bin/telco5g-jira.py
+++ b/bin/telco5g-jira.py
@@ -52,10 +52,10 @@ def main():
     else:
         cfg['debug'] = False
 
-    # Check for the password
+    # Check for the Jira PAT
     if len(cfg['password']) <= 0:
         if sys.stdin.isatty():
-            cfg['password'] = getpass.getpass('Enter the Jira password: ')
+            cfg['password'] = getpass.getpass('Enter the Jira PAT: ')
         else:
             cfg['password'] = sys.stdin.readline().rstrip()
 
@@ -71,13 +71,12 @@ def main():
         dpp.pprint(cases)
     
     print('Connecting to Jira instance')
-    options = { 'server': cfg['server'] }
 
     try:
-        conn = libtelco5g.jira_connection(options, cfg)
+        conn = libtelco5g.jira_connection(cfg)
     except jira.exceptions as e:
         if e.status_code ==401:
-            print("Login to JIRA failed. Check your username and password")
+            print("Login to JIRA failed. Check your PAT")
             exit (1)
 
     if cfg['debug']:

--- a/cfg/sample.cfg
+++ b/cfg/sample.cfg
@@ -46,11 +46,7 @@
 # Jira Server Connection Information
 ; server      : https://issues.redhat.com
 
-# Jira User. If not specified, the name 
-# of the user executing the script is used.
-; user        : 
-
-# Jira User Password. If not specified, it will be prompted for via stdin.
+# Jira User Personal Access Token (PAT). If not specified, it will be prompted for via stdin.
 # Can also be piped into the script. e.g. cat passwd.file | telco5g-jira.py
 ; password    : 
 

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -25,10 +25,8 @@ def set_cfg():
     cfg['labels'] = cfg['labels'].split(',')
 
     cfg['offline_token'] = os.environ.get('offline_token')
-    cfg['user'] = os.environ.get('jira_user')
     cfg['password'] = os.environ.get('jira_pass')
     cfg['accounts'] = json.loads(os.environ.get('accounts'))
-    cfg['options'] = { 'server': cfg['server'] }
 
     return cfg
 
@@ -56,7 +54,7 @@ def get_new_comments():
     cfg = set_cfg()
 
     cfg['query'] = "case_summary:*webscale* OR case_tags:*shift_telco5g* OR case_summary:*cnv,* OR case_tags:*cnv*"   
-    conn = libtelco5g.jira_connection(cfg['options'], cfg)
+    conn = libtelco5g.jira_connection(cfg)
     board = libtelco5g.get_board_id(conn, cfg['board'])
     sprint = libtelco5g.get_latest_sprint(conn, board.id, cfg['sprintname'])
     cards = conn.search_issues("sprint=" + str(sprint.id) + " AND updated >= '-7d'", maxResults=1000)
@@ -91,7 +89,7 @@ def get_trending_cards():
     cfg = set_cfg()
     
     cfg['query'] = "case_summary:*webscale* OR case_tags:*shift_telco5g* OR case_summary:*cnv,* OR case_tags:*cnv*"    
-    conn = libtelco5g.jira_connection(cfg['options'], cfg)
+    conn = libtelco5g.jira_connection(cfg)
     board = libtelco5g.get_board_id(conn, cfg['board'])
     query_range = get_previous_quarter()
     cards = conn.search_issues('component = "KNI Labs & Field" AND (project = KNIECO OR project = KNIP AND issuetype = Epic AND status != Obsolete) AND labels = "Trends" AND ' + query_range + ' ORDER BY Rank ASC', maxResults=1000)
@@ -118,7 +116,7 @@ def get_trending_cards():
 def plots():
     # Set the default configuration values
     cfg = set_cfg()
-    conn =libtelco5g.jira_connection(cfg['options'], cfg)
+    conn = libtelco5g.jira_connection(cfg)
     project = libtelco5g.get_project_id(conn, cfg['project'])
     component = libtelco5g.get_component_id(conn, project.id, cfg['component'])
     board = libtelco5g.get_board_id(conn, cfg['board'])

--- a/dashboard/yaml/04_t5gweb-app-deployment.yml
+++ b/dashboard/yaml/04_t5gweb-app-deployment.yml
@@ -26,8 +26,6 @@ spec:
         env:
         - name: offline_token
           value: Offline_token
-        - name: jira_user
-          value: Jira_User
         - name: jira_pass
           value: Jira_Pass
         - name: accounts

--- a/k8s/build/cfg/t5g.cfg
+++ b/k8s/build/cfg/t5g.cfg
@@ -43,11 +43,7 @@
 # Jira Server Connection Information
 ; server      : https://issues.redhat.com
 
-# Jira User. If not specified, the name 
-# of the user executing the script is used.
-; user        : someuser
-
-# Jira User Password. If not specified, it will be prompted for via stdin.
+# Jira User Personal Access Token (PAT). If not specified, it will be prompted for via stdin.
 # Can also be piped into the script. e.g. cat passwd.file | telco5g-jira.py
 ; password    : somepassword
 

--- a/k8s/yaml/config-map-cnv.yml
+++ b/k8s/yaml/config-map-cnv.yml
@@ -14,7 +14,6 @@ data:
     sprintname    : T5GFE
     to          	: kgershon@redhat.com
     team         : [{"jira_user": "kgershon@redhat.com", "name": "Kobi Gershon", "accounts": []}]
-    user        	: Jira_User
     password    	: Jira_Pass
     offline_token : Offline_token
 kind: ConfigMap

--- a/k8s/yaml/config-map.yml
+++ b/k8s/yaml/config-map.yml
@@ -14,7 +14,6 @@ data:
     sprintname    : T5GFE
     to            : rh-telco5g-field-support@redhat.com
     team          : Team
-    user        	: Jira_User
     password    	: Jira_Pass
     offline_token : Offline_token
     slack_token		: Slack_token

--- a/telco5g-jira.py.md
+++ b/telco5g-jira.py.md
@@ -17,11 +17,8 @@ The script take an optional, but recommended, single option that specifies a con
 There is a sample file under the cfg directory.
 See the sample.cfg file for the default settings in the script.
 
-#### Jira User
-If the Jira user is not set using either the ***user*** key or the environment variable t5g_user, then the user will default to the currently logged in user.
-
-#### Jira Password
-The jira password can be specified multiple ways.
+#### Jira Personal Access Token (PAT)
+The jira PAT can be specified multiple ways.
  - password key in the configuration file
  - t5g_password environment variable
  - passwd via stdin to the command (echo passwd | telco5g-jira.py)


### PR DESCRIPTION
- Get rid of `jira_user` from docs and code
- change password to PAT in docs & comments
- change `jira_connection()` to use PAT instead of username/password
- created PAT for Jira bot account and assign it to `Jira_Pass` variable on GitLab 