### PR TITLE
Changing table scrolling

### DIFF
--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -87,7 +87,9 @@
         let table = $('#data').DataTable({
             "pageLength": 50,
             "scrollX": true,
-            "order": [[ 2, "desc" ]]
+            "scrollY": "75vh",
+            "order": [[ 2, "desc" ]],
+            "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]]
         });
 
         // Add event listener for opening and closing details


### PR DESCRIPTION
- Add option to view all table entries on same page per request
- Add vertical scrollbar so that you don't have to scroll to the bottom to use the horizontal scrollbar (Ex: https://datatables.net/examples/basic_init/scroll_xy.html)