### PR TITLE
Split summary and case status

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -281,7 +281,8 @@ def create_cards(cfg, new_cases, action='none'):
                 "tags": tags,
                 "labels": cfg['labels'],
                 "bugzilla": bz,
-                "severity": re.search(r'[a-zA-Z]+', cases[case]['severity']).group()
+                "severity": re.search(r'[a-zA-Z]+', cases[case]['severity']).group(),
+                "case_status": cases[case]['status']
             }
     
     return email_content, new_cards
@@ -599,7 +600,8 @@ def cache_cards(cfg):
             "bugzilla": bugzilla,
             "severity": re.search(r'[a-zA-Z]+', cases[case_number]['severity']).group(),
             "escalated": escalated,
-            "product": cases[case_number]['product']
+            "product": cases[case_number]['product'],
+            "case_status": cases[case_number]['status']
         }
 
     end = time.time()

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -117,7 +117,7 @@ def organize_cards(detailed_cards, telco_account_list, cnv_account_list=None):
     telco_accounts = {}
     cnv_accounts = {}
 
-    states = {"To Do":{}, "Open": {}, "In Progress": {}, "Code Review": {},"QE Review": {}, "Done": {}, "Won't Fix / Obsolete": {}}
+    states = {"Waiting on Red Hat":{}, "Waiting on Customer": {}, "Closed": {}}
     
     for account in telco_account_list:
         telco_accounts[account] = deepcopy(states)
@@ -126,7 +126,7 @@ def organize_cards(detailed_cards, telco_account_list, cnv_account_list=None):
             cnv_accounts[account] = deepcopy(states)
     
     for i in detailed_cards.keys():
-        status = detailed_cards[i]['card_status']
+        status = detailed_cards[i]['case_status']
         tags =  detailed_cards[i]['tags']
         account = detailed_cards[i]['account']
         #logging.warning("card: %s\tstatus: %s\ttags: %s\taccount: %s" % (i, status, tags, account))

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -34,21 +34,17 @@ def set_cfg():
 
     return cfg
 
-def get_new_cases():
+def get_new_cases(case_tag):
     """get new cases created since X days ago"""
 
     # get cases from cache
     cases = libtelco5g.redis_get("cases")
 
     interval = 7
-    new_cases = []
-    for case in sorted(cases.items(), key = lambda i: i[1]['severity']):
-        create_date = datetime.strptime(case[1]['createdate'], '%Y-%m-%dT%H:%M:%SZ')
-        time_diff = datetime.now() - create_date
-        if time_diff.days < 7:
-            case[1]['severity'] = re.sub('\(|\)| |[0-9]', '', case[1]['severity'])
-            case[1]['number'] = case[0]
-            new_cases.append(case[1])
+    today = date.today()
+    new_cases = {c: d for (c, d) in sorted(cases.items(), key = lambda i: i[1]['severity']) if case_tag in d['tags'] and (today - datetime.strptime(d['createdate'], '%Y-%m-%dT%H:%M:%SZ').date()).days < interval}
+    for case in new_cases:
+        new_cases[case]['severity'] = re.sub('\(|\)| |[0-9]', '', new_cases[case]['severity'])
     return new_cases
 
 def get_new_comments(new_comments_only=True):

--- a/dashboard/src/t5gweb/templates/ui/index.html
+++ b/dashboard/src/t5gweb/templates/ui/index.html
@@ -4,16 +4,29 @@
 
 <a id="top"></a>
 <div class="new-cases">
-    <h1>{{ new_cases | length }} Cases Opened in the Last 7 Days:</h1>
+    <h1>{{ new_t5g_cases | length }} Telco5G Cases Opened in the Last 7 Days:</h1>
+    <div class="copy">
+        <table class="table table-borderless table-hover">
+        <th>case#</th><th>severity</th><th>summary</th>
+        {% for case in new_t5g_cases %}
+        <tr>
+            <td><a href=https://access.redhat.com/support/cases/#/case/{{ case }} target="_blank">{{ case }}</a></td>
+            <td>{{ new_t5g_cases[case]['severity'] }}</td>
+            <td>{{ new_t5g_cases[case]['problem'] }}</td>
+        </tr>
+        {% endfor %}
+        </table>
+    </div>
+    <h1>{{ new_cnv_cases | length }} CNV Cases Opened in the Last 7 Days:</h1>
     <div class="copy">
         <table class="table table-borderless table-hover">
         <th>case#</th><th>severity</th><th>summary</th>
 
-        {% for case in new_cases %}
+        {% for case in new_cnv_cases %}
         <tr>
-            <td><a href=https://access.redhat.com/support/cases/#/case/{{ case.number }} target="_blank">{{ case.number }}</a></td>
-            <td>{{ case.severity }}</td>
-            <td>{{ case.problem }}</td>
+            <td><a href=https://access.redhat.com/support/cases/#/case/{{ case }} target="_blank">{{ case }}</a></td>
+            <td>{{ new_cnv_cases[case]['severity'] }}</td>
+            <td>{{ new_cnv_cases[case]['problem'] }}</td>
         </tr>
         {% endfor %}
         </table>

--- a/dashboard/src/t5gweb/templates/ui/index.html
+++ b/dashboard/src/t5gweb/templates/ui/index.html
@@ -4,7 +4,7 @@
 
 <a id="top"></a>
 <div class="new-cases">
-    <h1>{{ new_t5g_cases | length }} Telco5G Cases Opened in the Last 7 Days:</h1>
+    <h2>{{ new_t5g_cases | length }} <a href="{{ url_for('ui.telco5g') }}">Telco5G Cases</a> Opened in the Last 7 Days:</h2>
     <div class="copy">
         <table class="table table-borderless table-hover">
         <th>case#</th><th>severity</th><th>summary</th>
@@ -17,7 +17,7 @@
         {% endfor %}
         </table>
     </div>
-    <h1>{{ new_cnv_cases | length }} CNV Cases Opened in the Last 7 Days:</h1>
+    <h2>{{ new_cnv_cases | length }} <a href="{{ url_for('ui.cnv') }}">CNV Cases</a> Opened in the Last 7 Days:</h2>
     <div class="copy">
         <table class="table table-borderless table-hover">
         <th>case#</th><th>severity</th><th>summary</th>

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -23,7 +23,7 @@
                                     <td class="align-middle text-center">{{ new_comments[account][status][card]['summary'] }}</td>
                                     <td class="align-middle text-center">{{ new_comments[account][status][card]['product'] }}</td>
                                     <td class="align-middle text-center">{{ new_comments[account][status][card]['account'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['card_status'] }}</td>
+                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['case_status'] }}</td>
                                     <td class="align-middle text-center">{{ new_comments[account][status][card]['assignee']['displayName'] }}</td>
                                     <td class="align-middle text-center"><a href=https://issues.redhat.com/browse/{{ card }} target="_blank">{{ card }}</a></td>
                                     <td class="align-middle text-center"><span class="fw-bold fst-italic">{{ new_comments[account][status][card]['comments'][-1][1][:10] }}</span> - {{ new_comments[account][status][card]['comments'][-1][0] | safe }}</td>

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -24,7 +24,9 @@ def load_data():
     """Load data for dashboard"""
     
     cfg = set_cfg()
-    load_data.new_cases = get_new_cases()
+    #new_cases = get_new_cases()
+    load_data.new_cnv_cases = get_new_cases('cnv')
+    load_data.new_t5g_cases = get_new_cases('shift_telco5g')
     plot_data = plots()
     load_data.y = list(plot_data.values())
     telco_accounts, cnv_accounts = get_new_comments()
@@ -40,7 +42,7 @@ def load_data():
 def index():
     """list new cases"""
     load_data()
-    return render_template('ui/index.html', new_cases=load_data.new_cases, values=load_data.y, now=load_data.now)
+    return render_template('ui/index.html', new_cnv_cases=load_data.new_cnv_cases, new_t5g_cases=load_data.new_t5g_cases, values=load_data.y, now=load_data.now)
 
 @BP.route('/refresh')
 def refresh():


### PR DESCRIPTION
- break out new t5g vs. cnv cases on homepage
- organise cards by case status instead of card status