### PR TITLE
fixing wrong comment bug

### DIFF
--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -60,6 +60,7 @@ def get_new_comments(new_comments_only=True):
     telco_account_list = []
     cnv_account_list = []
     for card in cards:
+        comments = []
         if new_comments_only:
             if cards[card]['comments'] is not None:
                 comments = [comment for comment in cards[card]['comments'] if (time_now - datetime.strptime(comment[1], '%Y-%m-%dT%H:%M:%S.%f%z')).days < 7]


### PR DESCRIPTION
When a new card is created and added to the cache, `comments` is set to None. But if you check the 'all updates' view, the new card shows up, with comments from another case. After the cache is refreshed proper, this problem goes away.

My theory is that somehow in the effected loop, `comments` is getting re-used instead of skipped, resulting in the mismatch. Clearing `comments` seems to fix it.