### PR TITLE
Table Sorting

### DIFF
--- a/dashboard/src/t5gweb/static/js/dataTables.deepLink.min.js
+++ b/dashboard/src/t5gweb/static/js/dataTables.deepLink.min.js
@@ -1,0 +1,43 @@
+/*!
+   Copyright 2017 SpryMedia Ltd.
+
+ License      MIT - http://datatables.net/license/mit
+
+ This feature plug-in for DataTables provides a function which will
+ take DataTables options from the browser's URL search string and
+ return an object that can be used to construct a DataTable. This
+ allows deep linking to be easily implemented with DataTables - for
+ example a URL might be `myTable?displayStart=10` which will
+ automatically cause the second page of the DataTable to be displayed.
+
+ This plug-in works on a whitelist basis - you must specify which
+ [initialisation parameters](//datatables.net/reference/option) you
+ want the URL search string to specify. Any parameter given in the
+ URL which is not listed will be ignored (e.g. you are unlikely to
+ want to let the URL search string specify the `ajax` option).
+
+ This specification is done by passing an array of property names
+ to the `$.fn.dataTable.ext.deepLink` function. If you do which to
+ allow _every_ parameter (I wouldn't recommend it) you can use `all`
+ instead of an array.
+
+ @example
+   // Allow a display start point and search string to be specified
+   $('#myTable').DataTable(
+     $.fn.dataTable.ext.deepLink( [ 'displayStart', 'search.search' ] )
+   );
+
+ @example
+   // As above, but with a default search
+   var options = $.fn.dataTable.ext.deepLink(['displayStart', 'search.search']);
+
+   $('#myTable').DataTable(
+     $.extend( true, {
+       search: { search: 'Initial search value' }
+     }, options )
+   );
+ Deep linking options parsing support for DataTables
+ 2017 SpryMedia Ltd - datatables.net/license
+*/
+(function(l,m,b,n){var h=b.fn.dataTable.ext.internal._fnSetObjectDataFn;b.fn.dataTable.ext.deepLink=function(e){for(var f=location.search.replace(/^\?/,"").split("&"),g={},c=0,k=f.length;c<k;c++){var a=f[c].split("="),d=decodeURIComponent(a[0]);a=decodeURIComponent(a[1]);if("true"===a)a=!0;else if("false"===a)a=!1;else if(!a.match(/[^\d]/)&&"search.search"!==d)a*=1;else if(0===a.indexOf("{")||0===a.indexOf("["))try{a=b.parseJSON(a)}catch(p){}"all"!==e&&-1===b.inArray(d,e)||h(d)(g,a)}return g}})(window,
+    document,jQuery);

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -34,6 +34,28 @@
                    <path fill-rule="evenodd" d="M7.293 1.5a1 1 0 0 1 1.414 0l6.647 6.646a.5.5 0 0 1-.708.708L8 2.207 1.354 8.854a.5.5 0 1 1-.708-.708L7.293 1.5z"/>
                  </svg></a>
              </li>
+             <li class="nav-item dropdown">
+               <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                 Tables
+               </a>
+               <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDropdown">
+                 <li><a class="dropdown-item" href="{{ url_for('ui.telco_severity') }}">Telco5G Updates</a></li>
+                 <li><a class="dropdown-item" href="{{ url_for('ui.cnv_severity') }}">CNV Updates</a></li>
+                 <li><a class="dropdown-item" href="{{ url_for('ui.telco_all_severity') }}">All Telco5g Cards</a></li>
+                 <li><a class="dropdown-item" href="{{ url_for('ui.cnv_all_severity') }}">All CNV Cards</a></li>
+               </ul>
+             </li>
+             <li class="nav-item dropdown">
+               <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                 Reports
+               </a>
+               <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDropdown">
+                 <li><a class="dropdown-item" href="{{ url_for('ui.telco5g') }}">Telco5G Updates</a></li>
+                 <li><a class="dropdown-item" href="{{ url_for('ui.cnv') }}">CNV Updates</a></li>
+                 <li><a class="dropdown-item" href="{{ url_for('ui.all_telco5g') }}">All Telco5g Cards</a></li>
+                 <li><a class="dropdown-item" href="{{ url_for('ui.all_cnv') }}">All CNV Cards</a></li>
+               </ul>
+             </li>
              <li class="nav-item ms-2">
                <a role="button" class="btn btn-dark" href="{{ url_for('ui.trends') }}"><svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" role="img" aria-label="Trends" class="bi bi-graph-up-arrow" viewBox="0 0 16 16">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0h1v15h15v1H0V0Zm10 3.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-1 0V4.9l-3.613 4.417a.5.5 0 0 1-.74.037L7.06 6.767l-3.656 5.027a.5.5 0 0 1-.808-.588l4-5.5a.5.5 0 0 1 .758-.06l2.609 2.61L13.445 4H10.5a.5.5 0 0 1-.5-.5Z"/>

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -2,7 +2,6 @@
 {% block title %}{{ page_title }}{% endblock %}
 {% block content %}
 <div class="container-fluid copy mt-5">
-    <a role="button" class="btn btn-outline-dark btn-lg mb-2" href="{{ request.url[:-9] }}">Back to Report</a>
     <table class="table table-bordered table-hover table-responsive mt-5 w-100" id="data">
         <caption style="caption-side: top; text-align: center;">Note: Use shift+click to sort by multiple columns</caption>
         <thead>
@@ -46,6 +45,7 @@
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net/js/jquery.dataTables.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net-bs5/js/dataTables.bootstrap5.min.js') }}"></script>
+   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/plug-ins/1.11.5/features/deepLink/dataTables.deepLink.min.js"></script>
    <script>
     function format(data) {
         let result = "<div class='card p-3'>"
@@ -85,13 +85,17 @@
     };
 
     $(document).ready(function () {
-        let table = $('#data').DataTable({
+        let searchOptions = $.fn.dataTable.ext.deepLink([
+            'search.search', 'order', 'displayStart'
+        ]);
+        let options = {
             "pageLength": 50,
             "scrollX": true,
             "scrollY": "75vh",
-            "order": [[ 2, "desc" ], [3, "desc"]],
+            "order": [[2, "desc"], [3, "desc"]],
             "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]]
-        });
+        };
+        let table = $('#data').DataTable($.extend(options, searchOptions));
 
         // Add event listener for opening and closing details
         $('#data').on('click', 'td.dt-control', function () {

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -45,7 +45,7 @@
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net/js/jquery.dataTables.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net-bs5/js/dataTables.bootstrap5.min.js') }}"></script>
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/plug-ins/1.11.5/features/deepLink/dataTables.deepLink.min.js"></script>
+   <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='js/dataTables.deepLink.min.js') }}"></script>
    <script>
     function format(data) {
         let result = "<div class='card p-3'>"

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -4,6 +4,7 @@
 <div class="container-fluid copy mt-5">
     <a role="button" class="btn btn-outline-dark btn-lg mb-2" href="{{ request.url[:-9] }}">Back to Report</a>
     <table class="table table-bordered table-hover table-responsive mt-5 w-100" id="data">
+        <caption style="caption-side: top; text-align: center;">Note: Use shift+click to sort by multiple columns</caption>
         <thead>
             <tr><th></th><th class="text-center">Case#</th><th class="text-center">Severity</th><th class="text-center">Escalated?</th><th class="text-center">Summary</th><th class="text-center">Product</th><th class="text-center">Account</th><th class="text-center">Status</th><th class="text-center">Assignee</th><th class="text-center">Jira</th><th class="text-center">Most Recent Comment</th><th class="text-center">Bugzillas</th></tr>
         </thead>
@@ -88,7 +89,7 @@
             "pageLength": 50,
             "scrollX": true,
             "scrollY": "75vh",
-            "order": [[ 2, "desc" ]],
+            "order": [[ 2, "desc" ], [3, "desc"]],
             "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]]
         });
 

--- a/dashboard/src/t5gweb/templates/ui/updates.html
+++ b/dashboard/src/t5gweb/templates/ui/updates.html
@@ -7,7 +7,7 @@
          <div class="col-2">
                      <!-- Sidebar Derived from https://getbootstrap.com/docs/5.1/examples/#snippets -->
             <div class="flex-shrink-0 p-3 bg-white sticky-top sb">
-               <a role="button" class="btn btn-outline-dark btn-lg mb-2" href="{{ request.url + '/severity' }}">Sort By Severity</a>
+               <a role="button" class="btn btn-outline-dark btn-lg mb-2" href="{{ request.url + '/severity' }}">Table View</a>
                <ul class="list-unstyled ps-0">           
                   {% for account in new_comments %}
                   <li class="mb-1">    


### PR DESCRIPTION

- Change text of buttons from `Sort by Severity` to `Table View`
- Sort the tables by `Severity` and `Escalated?` by default
- Add note telling users how to sort by multiple columns
- Add the datatables deeplink plugin locally rather than installing via NPM. To install the deeplink plugin via NPM, you'd have to install all of the plugins along with it leading to a package size of [~1MB](https://www.npmjs.com/package/datatables.net-plugins), while the file we're looking at is only [~2KB](https://github.com/DataTables/Plugins/blob/f10a04087f0c081d7884ddd6631723efbe695f89/features/deepLink/dataTables.deepLink.min.js).
- Add dropdown Menus to header w/ links to all reports and tables
