### PR TITLE
fixing csv'ed tags

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -578,7 +578,12 @@ def cache_cards(cfg):
         }
         tags = []
         if 'tags' in cases[case_number].keys():
-            tags = cases[case_number]['tags']
+            case_tags = cases[case_number]['tags']
+            if len(case_tags) == 1:
+                logging.warning("bad?")
+                tags = case_tags[0].split(';') # csv instead of a proper list
+            else:
+                tags = case_tags
         else: # assume telco
             tags = ['shift_telco5g']
         if 'bug' in cases[case_number].keys() and case_number in bugs.keys():


### PR DESCRIPTION
Some cases were not showing up in the report or the table. This is because some cases have tags of a form `['tag1;tag2;tag3']` where we assume `['tag1', 'tag2', 'tag3']`.

This change ensures all tags are proper lists.