### PR TITLE
Don't try to close cases that are obsoleted

### DIFF
--- a/bin/cases_to_close.py
+++ b/bin/cases_to_close.py
@@ -18,7 +18,7 @@ def check_cases(api_url, case_tag):
         sys.exit(1)
     cards = requests.get("{}/api/cards/{}".format(api_url, case_tag))
     if cases.status_code == 200:
-        open_cards = {c: d for (c, d) in cards.json().items() if d['card_status'] != 'Done'}
+        open_cards = {c: d for (c, d) in cards.json().items() if d['card_status'] not in ('Done', 'Won\'t Fix / Obsolete')}
     else:
         print("could not retrieve cards: {}".format(cards.status_code))
         sys.exit(1)


### PR DESCRIPTION
Just a super minor bug. When checking for closed cases with open cards, `Won't Fix / Obsolete` should be excluded since they are considered resolved in Jira.