### PR TITLE
retry if cache task fails + tweaks

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -240,7 +240,10 @@ def create_cards(cfg, new_cases, action='none'):
             logging.warning('creating card for case {}'.format(case))
             new_card = jira_conn.create_issue(fields=card_info)
             logging.warning('created {}'.format(new_card.key))
-            email_content.append( f"A JIRA issue (https://issues.redhat.com/browse/{new_card}) has been created for a new Telco5G case:\nCase #: {case} (https://access.redhat.com/support/cases/{case})\nAccount: {cases[case]['account']}\nSummary: {cases[case]['problem']}\nSeverity: {cases[case]['severity']}\nDescription: {cases[case]['description']}\n\nIt is initially being tracked by {assignee['name']}.\n")
+            if 'field' in card_info['labels']:
+                email_content.append( f"A JIRA issue (https://issues.redhat.com/browse/{new_card}) has been created for a new Telco5G case:\nCase #: {case} (https://access.redhat.com/support/cases/{case})\nAccount: {cases[case]['account']}\nSummary: {cases[case]['problem']}\nSeverity: {cases[case]['severity']}\nDescription: {cases[case]['description']}\n\nIt is initially being tracked by {assignee['name']}.\n")
+            else:
+                email_content.append( f"A JIRA issue (https://issues.redhat.com/browse/{new_card}) has been created for a new CNV case:\nCase #: {case} (https://access.redhat.com/support/cases/{case})\nAccount: {cases[case]['account']}\nSummary: {cases[case]['problem']}\nSeverity: {cases[case]['severity']}\nDescription: {cases[case]['description']}\n\nIt is initially being tracked by {assignee['name']}.\n")
 
             # Add newly create card to the sprint
             logging.warning('moving card to sprint {}'.format(sprint.id))

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -42,7 +42,7 @@ def get_new_cases(case_tag):
 
     interval = 7
     today = date.today()
-    new_cases = {c: d for (c, d) in sorted(cases.items(), key = lambda i: i[1]['severity']) if case_tag in d['tags'] and (today - datetime.strptime(d['createdate'], '%Y-%m-%dT%H:%M:%SZ').date()).days < interval}
+    new_cases = {c: d for (c, d) in sorted(cases.items(), key = lambda i: i[1]['severity']) if case_tag in d['tags'] and (today - datetime.strptime(d['createdate'], '%Y-%m-%dT%H:%M:%SZ').date()).days <= interval}
     for case in new_cases:
         new_cases[case]['severity'] = re.sub('\(|\)| |[0-9]', '', new_cases[case]['severity'])
     return new_cases

--- a/dashboard/src/t5gweb/taskmgr.py
+++ b/dashboard/src/t5gweb/taskmgr.py
@@ -32,7 +32,7 @@ def setup_scheduled_tasks(sender, **kwargs):
 
     # update card cache
     sender.add_periodic_task(
-        crontab(hour='*', minute='0'), # on the hour
+        crontab(hour='*', minute='21'), # on the hour + offset
         cache_data.s('cards'),
         name='card_sync',
     )
@@ -135,7 +135,7 @@ def portal_jira_sync(job_type):
     end = time.time()
     logging.warning("synced to jira in {} seconds".format(end - start))
 
-@mgr.task
+@mgr.task(autoretry_for=(Exception,), max_retries=5, retry_backoff=30)
 def cache_data(data_type):
     
     logging.warning("job: sync {}".format(data_type))


### PR DESCRIPTION
- add retries to `cache_data`
- change notification message for t5g vs cnv
- align front page 'week' with a stats 'week'

fix #111 