### PR TITLE
Set escalated flag on new cards

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -818,7 +818,7 @@ def generate_stats(case_type):
                 stats['watched'] += 1
             if cards[card]['bugzilla'] is None:
                 stats['no_bzs'] += 1
-            if (today - datetime.datetime.strptime(data['card_created'], '%Y-%m-%dT%H:%M:%S.000+0000').date()).days <= 1:
+            if (today - datetime.datetime.strptime(data['card_created'], '%Y-%m-%dT%H:%M:%S.%f%z').date()).days <= 1:
                 stats['daily_opened_cases'] += 1
 
     for (case, data) in cases.items():

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -286,7 +286,10 @@ def create_cards(cfg, new_cases, action='none'):
                 "labels": cfg['labels'],
                 "bugzilla": bz,
                 "severity": re.search(r'[a-zA-Z]+', cases[case]['severity']).group(),
-                "case_status": cases[case]['status']
+                "case_status": cases[case]['status'],
+                "escalated": False,
+                "watched": False,
+                "crit_sit": False
             }
     
     return email_content, new_cards

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -170,9 +170,9 @@ def init_cache():
     if bugs == {} or details == {}:
         logging.warning("no details found in cache. refreshing...")
         libtelco5g.cache_details(cfg)
-    #if escalations == {}:
-    #    logging.warning("no escalations found in cache. refreshing...")
-    #    libtelco5g.cache_escalations(cfg)
+    if escalations == {}:
+        logging.warning("no escalations found in cache. refreshing...")
+        libtelco5g.cache_escalations(cfg)
     if watchlist == {}:
         logging.warning("no watchlist found in cache. refreshing...")
         libtelco5g.cache_watchlist(cfg)

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -164,25 +164,25 @@ def init_cache():
     watchlist = libtelco5g.redis_get('watchlist')
     t5g_stats = libtelco5g.redis_get('telco5g_stats')
     cnv_stats = libtelco5g.redis_get('cnv_stats')
-    if cases is None:
+    if cases == {}:
         logging.warning("no cases found in cache. refreshing...")
         libtelco5g.cache_cases(cfg)
-    if bugs is None or details is None:
+    if bugs == {} or details == {}:
         logging.warning("no details found in cache. refreshing...")
         libtelco5g.cache_details(cfg)
-    if escalations is None:
-        logging.warning("no escalations found in cache. refreshing...")
-        libtelco5g.cache_escalations(cfg)
-    if watchlist is None:
+    #if escalations == {}:
+    #    logging.warning("no escalations found in cache. refreshing...")
+    #    libtelco5g.cache_escalations(cfg)
+    if watchlist == {}:
         logging.warning("no watchlist found in cache. refreshing...")
         libtelco5g.cache_watchlist(cfg)
-    if cards is None:
+    if cards == {}:
         logging.warning("no cards found in cache. refreshing...")
         libtelco5g.cache_cards(cfg)
     if t5g_stats == {}:
         logging.warning("no t5g stats found in cache. refreshing...")
         libtelco5g.cache_stats('telco5g')
-    if cnv_stats is None:
+    if cnv_stats == {}:
         logging.warning("no cnv stats found in cache. refreshing...")
         libtelco5g.cache_stats('cnv')
 


### PR DESCRIPTION
Fixing a couple of issues around stats and new cards. When new cards are created, but before a full resync happens (so a window of 45 minutes) the stats page failed to render due to missing keys in the cards. This will fix that along with an init bug