### PR TITLE
Progress bar

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -545,7 +545,7 @@ def cache_escalations(cfg):
 
     redis_set('escalations', json.dumps(escalations))
 
-def cache_cards(cfg):
+def cache_cards(cfg, self=None, background=False):
 
     cases = redis_get('cases')
     bugs = redis_get('bugs')
@@ -572,7 +572,13 @@ def cache_cards(cfg):
     time_now = datetime.datetime.now(datetime.timezone.utc)
 
     jira_cards = {}
-    for card in card_list:
+    for index, card in enumerate(card_list):
+        if background:
+            # Update task information for progress bar
+            self.update_state(state='PROGRESS',
+                              meta={'current': index, 'total': len(card_list),
+                                    'status': "Refreshing Cards in Background..."}
+                            )
         issue = jira_conn.issue(card)
         comments = jira_conn.comments(issue)
         card_comments = []

--- a/dashboard/src/t5gweb/static/js/refresh.js
+++ b/dashboard/src/t5gweb/static/js/refresh.js
@@ -1,0 +1,71 @@
+/**
+ * The following code, along with refresh() and refresh_status() in t5gweb/ui.py
+ * was derived from https://blog.miguelgrinberg.com/post/using-celery-with-flask 
+ * under the following license:
+    
+ *   The MIT License (MIT)
+
+ *   Copyright (c) 2014 Miguel Grinberg
+
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+ function getBackground() {
+    $('#progressbar').empty();
+    div = $('<div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
+    $('#progressbar').append(div);
+    $.ajax({
+        type: 'POST',
+        url: '/refresh',
+        success: function (data, status, request) {
+            status_url = request.getResponseHeader('Location');
+            updatePercentage(status_url, $('#progressbar'))
+        },
+        error: function () {
+            alert('Unexpected error')
+        }
+    })
+}
+
+function updatePercentage(status_url, div) {
+    $.getJSON(status_url, function (data) {
+        console.log(data);
+        percent = parseInt(data['current'] * 100 / data['total']);
+        div.find(".progress-bar").css('width', percent + '%').attr('aria-valuenow', percent).text(percent + "%");
+        if (data['state'] != 'PENDING' && data['state'] != 'PROGRESS') {
+            if ('result' in data) {
+                // show result
+                $(div).text(data['result']).css('color', 'white');
+            }
+            else {
+                // something unexpected happened
+                $(div).text(data['state'] + ", please try again.").css('color', 'white');
+            }
+        } else {
+            // rerun in 2 seconds
+            setTimeout(function () {
+                updatePercentage(status_url, div);
+            }, 2000);
+        }
+    })
+}
+
+$(function () {
+    $('#refresh').click(getBackground);
+});

--- a/dashboard/src/t5gweb/static/js/refresh.js
+++ b/dashboard/src/t5gweb/static/js/refresh.js
@@ -26,6 +26,11 @@
  *   SOFTWARE.
  */
 
+/**
+ * On page load, get status of most recent background refresh
+ * If refresh is in progress, display progress bar and call updatePercentage()
+ * to continously update it.
+ */
  $(document).ready(function () {
     $.ajax({
         type: 'POST',
@@ -49,6 +54,11 @@
     });
 });
 
+/**
+ * getBackground() displays the progress bar when the refresh button is clicked
+ * and gets progress information from the task. Also calls updatePercentage()
+ * to continously update the progress bar.
+ */
 function getBackground() {
     $('#progressbar').empty();
     div = $('<div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
@@ -66,6 +76,10 @@ function getBackground() {
     })
 }
 
+/**
+ * updatePercentage() gets the progress of the refresh and updates the progress bar
+ * every two seconds. Also displays the final result of the task.
+ */
 function updatePercentage(status_url, div) {
     $.getJSON(status_url, function (data) {
         console.log(data);
@@ -91,6 +105,9 @@ function updatePercentage(status_url, div) {
     })
 }
 
+/**
+ * Start background refresh on button click
+ */
 $(function () {
     $('#refresh').click(getBackground);
 });

--- a/dashboard/src/t5gweb/static/js/refresh.js
+++ b/dashboard/src/t5gweb/static/js/refresh.js
@@ -40,7 +40,7 @@
             $.getJSON(status_url, function (data) {
                 if (data['state'] == 'PROGRESS') {
                     $('#progressbar').empty();
-                    div = $('<div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
+                    div = $('<div class="text-center text-white">Refresh in progress...</div> <div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
                     $('#progressbar').append(div);
                     updatePercentage(status_url, $('#progressbar'));
                 }
@@ -59,7 +59,7 @@
  */
 function getBackground() {
     $('#progressbar').empty();
-    div = $('<div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
+    div = $('<div class="text-center text-white">Refresh in progress...</div> <div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
     $('#progressbar').append(div);
     $.ajax({
         type: 'POST',

--- a/dashboard/src/t5gweb/static/js/refresh.js
+++ b/dashboard/src/t5gweb/static/js/refresh.js
@@ -37,9 +37,7 @@
         url: '/progress/status',
         success: function (data, status, request) {
             status_url = request.getResponseHeader('Location');
-            console.log(data);
             $.getJSON(status_url, function (data) {
-                console.log(data['state']);
                 if (data['state'] == 'PROGRESS') {
                     $('#progressbar').empty();
                     div = $('<div class="text-white progress"><div class="progress-bar bg-danger" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div></div>');
@@ -82,7 +80,6 @@ function getBackground() {
  */
 function updatePercentage(status_url, div) {
     $.getJSON(status_url, function (data) {
-        console.log(data);
         percent = parseInt(data['current'] * 100 / data['total']);
         div.find(".progress-bar").css('width', percent + '%').attr('aria-valuenow', percent).text(percent + "%");
         if (!('locked' in data)) {

--- a/dashboard/src/t5gweb/taskmgr.py
+++ b/dashboard/src/t5gweb/taskmgr.py
@@ -9,6 +9,7 @@ import t5gweb.t5gweb as t5gweb
 from celery import Celery
 from celery.schedules import crontab
 import bugzilla
+import redis
 
 mgr = Celery('t5gweb', broker='redis://redis:6379/0', backend='redis://redis:6379/0')
 
@@ -188,9 +189,23 @@ def cache_stats():
 
 @mgr.task(bind=True)
 def refresh_background(self):
-    '''Refresh Jira cards cache in background.'''
+    '''Refresh Jira cards cache in background. If the refresh is already in progress, the task will be locked and won't run.
+    The lock is released when the task completes or after five minutes.
+    Lock code derived from http://loose-bits.com/2010/10/distributed-task-locking-in-celery.html
+    '''
 
-    cfg = t5gweb.set_cfg()
-    libtelco5g.cache_cards(cfg, self, background=True)
-    response = {'current': 100, 'total': 100, 'status': 'Done', 'result': 'Refresh Complete'}
+    have_lock = False
+    refresh_lock = redis.Redis(host='127.0.0.1').lock("refresh_lock", timeout=60*5)
+    try:
+        have_lock = refresh_lock.acquire(blocking=False)
+        if have_lock:
+            libtelco5g.redis_set('refresh_id', json.dumps(self.request.id))
+            cfg = t5gweb.set_cfg()
+            libtelco5g.cache_cards(cfg, self, background=True)
+            response = {'current': 100, 'total': 100, 'status': 'Done', 'result': 'Refresh Complete'}
+        else:
+            response = {'locked': 'Task is Locked'}
+    finally:
+        if have_lock:
+            refresh_lock.release()
     return response

--- a/dashboard/src/t5gweb/taskmgr.py
+++ b/dashboard/src/t5gweb/taskmgr.py
@@ -185,3 +185,12 @@ def cache_stats():
     for case_type in ['telco5g', 'cnv']:
         logging.warning("job: cache {} stats".format(case_type))
         libtelco5g.cache_stats(case_type)
+
+@mgr.task(bind=True)
+def refresh_background(self):
+    '''Refresh Jira cards cache in background.'''
+
+    cfg = t5gweb.set_cfg()
+    libtelco5g.cache_cards(cfg, self, background=True)
+    response = {'current': 100, 'total': 100, 'status': 'Done', 'result': 'Refresh Complete'}
+    return response

--- a/dashboard/src/t5gweb/taskmgr.py
+++ b/dashboard/src/t5gweb/taskmgr.py
@@ -195,7 +195,7 @@ def refresh_background(self):
     '''
 
     have_lock = False
-    refresh_lock = redis.Redis(host='127.0.0.1').lock("refresh_lock", timeout=60*5)
+    refresh_lock = redis.Redis(host='redis').lock("refresh_lock", timeout=60*5)
     try:
         have_lock = refresh_lock.acquire(blocking=False)
         if have_lock:

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -15,6 +15,9 @@
   <!-- Include ChartJS -->
   <script src="{{ url_for('static', filename='node_modules/chart.js/dist/chart.js') }}"></script>
 
+  <!-- Include JQuery -->
+  <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
+
   <!-- Include Datatables CSS -->
   <link rel="stylesheet" href="{{ url_for('static', filename='node_modules/datatables.net-bs5/css/dataTables.bootstrap5.min.css') }}"/>
   <link rel="stylesheet" href="{{ url_for('static', filename='node_modules/datatables.net-searchpanes-bs5/css/searchPanes.bootstrap5.min.css') }}"/>
@@ -80,7 +83,7 @@
                  </svg></button>
              </li>
              <li class="nav-item ms-2 me-2">
-               <a role="button" class="btn btn-dark" href="{{ url_for('ui.refresh') }}"><svg alt="Refresh" xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" role="img" aria-label="Refresh" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+              <a role="button" class="btn btn-dark" id="refresh"><svg alt="Refresh" xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" role="img" aria-label="Refresh" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
                    <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>
                    <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>
                  </svg></a>
@@ -89,6 +92,7 @@
           <span class="navbar-text">
              Last generated on {{ now }} UTC
           </span>
+          <div id="progressbar" class="w-50"></div>
           <ul class="navbar-nav ms-auto">
              <li class="nav-item">
                 <a role = "button" class="btn btn-dark btn-lg" href="https://github.com/RHsyseng/t5g-field-support-team-utils"><svg alt="github" xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">
@@ -115,7 +119,9 @@
 
   <!-- Include Bootstrap JS Bundle -->
   <script src="{{ url_for('static', filename='node_modules/bootstrap/dist/js/bootstrap.bundle.min.js') }}"></script>
-  <script>
+   
+  <!-- Copy Button JS-->
+ <script>
       var clipboard = new ClipboardJS('.btn');
       clipboard.on('success', function (e) {
          console.log(e);
@@ -125,6 +131,8 @@
          console.log(e);
       });
   </script>
+
+<script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='js/refresh.js') }}"></script>
 </body>
 
 </html>

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -14,7 +14,7 @@
 
   <!-- Include ChartJS -->
   <script src="{{ url_for('static', filename='node_modules/chart.js/dist/chart.js') }}"></script>
-
+  
   <!-- Include JQuery -->
   <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
 
@@ -119,9 +119,8 @@
 
   <!-- Include Bootstrap JS Bundle -->
   <script src="{{ url_for('static', filename='node_modules/bootstrap/dist/js/bootstrap.bundle.min.js') }}"></script>
-   
   <!-- Copy Button JS-->
- <script>
+  <script>
       var clipboard = new ClipboardJS('.btn');
       clipboard.on('success', function (e) {
          console.log(e);

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -119,6 +119,7 @@
 
   <!-- Include Bootstrap JS Bundle -->
   <script src="{{ url_for('static', filename='node_modules/bootstrap/dist/js/bootstrap.bundle.min.js') }}"></script>
+  
   <!-- Copy Button JS-->
   <script>
       var clipboard = new ClipboardJS('.btn');

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -92,7 +92,7 @@
           <span class="navbar-text">
              Last generated on {{ now }} UTC
           </span>
-          <div id="progressbar" class="w-50"></div>
+          <div id="progressbar" class="w-25 ps-3 pe-3"></div>
           <ul class="navbar-nav ms-auto">
              <li class="nav-item">
                 <a role = "button" class="btn btn-dark btn-lg" href="https://github.com/RHsyseng/t5g-field-support-team-utils"><svg alt="github" xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" class="bi bi-github" viewBox="0 0 16 16">

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -47,6 +47,15 @@ def index():
     load_data()
     return render_template('ui/index.html', new_cnv_cases=load_data.new_cnv_cases, new_t5g_cases=load_data.new_t5g_cases, values=load_data.y, now=load_data.now)
 
+@BP.route('/progress/status', methods=['POST'])
+def progress_status():
+    """On page load: if refresh is in progress, get task information for progress bar display"""
+    refresh_id = redis_get('refresh_id')
+    if refresh_id != {}:
+        return jsonify({}), 202, {'Location': url_for('ui.refresh_status', task_id=refresh_id)}
+    else:
+        return jsonify({})
+
 @BP.route('/status/<task_id>')
 def refresh_status(task_id):
     """Provide updates for refresh_background task"""
@@ -68,6 +77,8 @@ def refresh_status(task_id):
         }
         if 'result' in task.info:
             response['result'] = task.info['result']
+        if 'locked' in task.info:
+            response['locked'] = task.info['locked']
     else:
         # something went wrong in the background job
         response = {

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -2,8 +2,9 @@
 import logging
 import datetime
 from flask import (
-    Blueprint, redirect, render_template, request, url_for, make_response, send_file, request
+    Blueprint, jsonify, redirect, render_template, request, url_for, make_response, send_file, request
 )
+from t5gweb.taskmgr import refresh_background
 from t5gweb.t5gweb import (
     get_new_cases,
     get_new_comments,
@@ -46,13 +47,44 @@ def index():
     load_data()
     return render_template('ui/index.html', new_cnv_cases=load_data.new_cnv_cases, new_t5g_cases=load_data.new_t5g_cases, values=load_data.y, now=load_data.now)
 
-@BP.route('/refresh')
+@BP.route('/status/<task_id>')
+def refresh_status(task_id):
+    """Provide updates for refresh_background task"""
+    task = refresh_background.AsyncResult(task_id)
+    if task.state == 'PENDING':
+        # job did not start yet
+        response = {
+            'state': task.state,
+            'current': 0,
+            'total': 1,
+            'status': 'Pending...'
+        }
+    elif task.state != 'FAILURE':
+        response = {
+            'state': task.state,
+            'current': task.info.get('current', 0),
+            'total': task.info.get('total', 1),
+            'status': task.info.get('status', '')
+        }
+        if 'result' in task.info:
+            response['result'] = task.info['result']
+    else:
+        # something went wrong in the background job
+        response = {
+            'state': task.state,
+            'current': 1,
+            'total': 1,
+            'status': str(task.info) # this is the exception raised
+        }
+    return jsonify(response)
+
+@BP.route('/refresh', methods=['POST'])
 def refresh():
     """Forces an update to the dashboard"""
-    cfg = set_cfg()
-    cache_cards(cfg)
+    task = refresh_background.delay()
     load_data()
-    return redirect(url_for("ui.telco5g"))
+    return jsonify({}), 202, {'Location': url_for('ui.refresh_status', task_id=task.id)}
+
 
 @BP.route('/updates/telco5g')
 def telco5g():


### PR DESCRIPTION
- Change `refresh()` to be a background celery task so that users can still navigate dashboard while the refresh is running
- Add endpoints for refresh task status/progress
- Use Javascript to display refresh task status as a progress bar