### PR TITLE
Hide tables until loaded and add loading message

### DIFF
--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -2,81 +2,83 @@
 {% block title %}{{ page_title }}{% endblock %}
 {% block content %}
 <div class="container-fluid copy mt-5">
-    <div class="container-fluid pt-2">
+    <div class="container-fluid pt-2" id="expand-buttons">
         <button type="button" class="btn btn-outline-dark" id="expand-button">Expand All Rows</button> <button type="button" class="btn btn-outline-dark" id="collapse-button">Collapse All Rows</button>
     </div>
-    <table class="table table-bordered table-hover table-responsive mt-5 w-100" id="data">
-        <caption style="caption-side: top; text-align: center;">Note: Use shift+click to sort by multiple columns</caption>
-        <thead>
-            <tr>
-                <th rowspan="2"></th>
-                <th rowspan="2" class="text-center">Case#</th>
-                <th rowspan="2" class="text-center">Severity</th>
-                <th colspan="3" class="text-center">Escalations</th>
-                <th rowspan="2" class="text-center">Summary</th>
-                <th rowspan="2" class="text-center">Product</th>
-                <th rowspan="2" class="text-center">Case Group</th>
-                <th rowspan="2" class="text-center">Account</th>
-                <th rowspan="2" class="text-center">Status</th>
-                <th rowspan="2" class="text-center">Assignee</th>
-                <th rowspan="2" class="text-center">Jira</th>
-                <th rowspan="2" class="text-center">Most Recent Comment</th>
-                <th rowspan="2" class="text-center">Bugzillas</th>
-                <th rowspan="2" class="text-center">Days Open</th>
-                <th rowspan="2" class="text-center">Case Last Updated</th>
-            </tr>
-            <tr>
-                <th class="text-center">On Prio-list?</th>
-                <th class="text-center">On Watchlist?</th>
-                <th class="text-center">Crit Sit?</th>
-            </tr>
-        </thead>
-        <tbody class="list">
-                {% for account in new_comments %}
-                    {% for status in new_comments[account] %}
-                        {% for card in new_comments[account][status]%}
-                                <tr data-child-data='{{ new_comments[account][status][card] | tojson }}'>
-                                    <td class="align-middle dt-control"></td>
-                                    <td class="align-middle text-center"><a href=https://access.redhat.com/support/cases/#/case/{{new_comments[account][status][card]['case_number'] }} target="_blank">{{ new_comments[account][status][card]['case_number'] }}</a></td>
-                                    <td class="align-middle text-center"><span class="badge severity {{ new_comments[account][status][card]['severity'] | lower() }}">{{ new_comments[account][status][card]['severity'] }}</span></td>
-                                    {% if new_comments[account][status][card]['escalated'] %}
-                                        <td class="align-middle text-center">Yes</td>
-                                    {% else %}
-                                        <td class="align-middle text-center">No</td>
-                                    {% endif %}
-                                    {% if new_comments[account][status][card]['watched'] %}
-                                        <td class="align-middle text-center">Yes</td>
-                                    {% else %}
-                                        <td class="align-middle text-center">No</td>
-                                    {% endif %}
-                                    {% if new_comments[account][status][card]['crit_sit'] %}
-                                        <td class="align-middle text-center">Yes</td>
-                                    {% else %}
-                                        <td class="align-middle text-center">No</td>
-                                    {% endif %}
-                                    <td class="align-middle">{{ new_comments[account][status][card]['summary'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['product'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['group_name'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['account'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['case_status'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['assignee']['displayName'] }} {% if new_comments[account][status][card]['contributor']['displayName'] %} <br><br><span class="fw-bold">Contributor:</span> {{ new_comments[account][status][card]['contributor']['displayName'] }} {% endif %}</td>
-                                    <td class="align-middle text-center"><a href=https://issues.redhat.com/browse/{{ card }} target="_blank">{{ card }}</a></td>
-                                    <td class="align-middle"><span class="fw-bold fst-italic">{{ new_comments[account][status][card]['comments'][-1][1][:10] }}</span> - {{ new_comments[account][status][card]['comments'][-1][0] | safe }}</td>
-                                    {% if new_comments[account][status][card]['bugzilla'] and new_comments[account][status][card]['bugzilla'] | length == 1  %}
-                                        <td class="align-middle text-center"><a href={{ new_comments[account][status][card]['bugzilla'][0]['bugzillaLink'] }} target="_blank">{{ new_comments[account][status][card]['bugzilla'][0]['bugzillaNumber'] }}</a></td>
-                                    {% elif new_comments[account][status][card]['bugzilla'] is none%}
-                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['bugzilla'] }}</td>
-                                    {% else %}
-                                        <td class="align-middle text-center">Multiple - Expand for Details</td>
-                                    {% endif %}
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['case_days_open'] }}</td>
-                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['case_updated_date'] }}</td>
-                                </tr>
-                        {% endfor %}        
+    <div class="case-table" style="display: none;">
+        <table class="table table-bordered table-hover table-responsive mt-5 w-100" id="data">
+            <caption style="caption-side: top; text-align: center;">Note: Use shift+click to sort by multiple columns</caption>
+            <thead>
+                <tr>
+                    <th rowspan="2"></th>
+                    <th rowspan="2" class="text-center">Case#</th>
+                    <th rowspan="2" class="text-center">Severity</th>
+                    <th colspan="3" class="text-center">Escalations</th>
+                    <th rowspan="2" class="text-center">Summary</th>
+                    <th rowspan="2" class="text-center">Product</th>
+                    <th rowspan="2" class="text-center">Case Group</th>
+                    <th rowspan="2" class="text-center">Account</th>
+                    <th rowspan="2" class="text-center">Status</th>
+                    <th rowspan="2" class="text-center">Assignee</th>
+                    <th rowspan="2" class="text-center">Jira</th>
+                    <th rowspan="2" class="text-center">Most Recent Comment</th>
+                    <th rowspan="2" class="text-center">Bugzillas</th>
+                    <th rowspan="2" class="text-center">Days Open</th>
+                    <th rowspan="2" class="text-center">Case Last Updated</th>
+                </tr>
+                <tr>
+                    <th class="text-center">On Prio-list?</th>
+                    <th class="text-center">On Watchlist?</th>
+                    <th class="text-center">Crit Sit?</th>
+                </tr>
+            </thead>
+            <tbody class="list">
+                    {% for account in new_comments %}
+                        {% for status in new_comments[account] %}
+                            {% for card in new_comments[account][status]%}
+                                    <tr data-child-data='{{ new_comments[account][status][card] | tojson }}'>
+                                        <td class="align-middle dt-control"></td>
+                                        <td class="align-middle text-center"><a href=https://access.redhat.com/support/cases/#/case/{{new_comments[account][status][card]['case_number'] }} target="_blank">{{ new_comments[account][status][card]['case_number'] }}</a></td>
+                                        <td class="align-middle text-center"><span class="badge severity {{ new_comments[account][status][card]['severity'] | lower() }}">{{ new_comments[account][status][card]['severity'] }}</span></td>
+                                        {% if new_comments[account][status][card]['escalated'] %}
+                                            <td class="align-middle text-center">Yes</td>
+                                        {% else %}
+                                            <td class="align-middle text-center">No</td>
+                                        {% endif %}
+                                        {% if new_comments[account][status][card]['watched'] %}
+                                            <td class="align-middle text-center">Yes</td>
+                                        {% else %}
+                                            <td class="align-middle text-center">No</td>
+                                        {% endif %}
+                                        {% if new_comments[account][status][card]['crit_sit'] %}
+                                            <td class="align-middle text-center">Yes</td>
+                                        {% else %}
+                                            <td class="align-middle text-center">No</td>
+                                        {% endif %}
+                                        <td class="align-middle">{{ new_comments[account][status][card]['summary'] }}</td>
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['product'] }}</td>
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['group_name'] }}</td>
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['account'] }}</td>
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['case_status'] }}</td>
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['assignee']['displayName'] }} {% if new_comments[account][status][card]['contributor']['displayName'] %} <br><br><span class="fw-bold">Contributor:</span> {{ new_comments[account][status][card]['contributor']['displayName'] }} {% endif %}</td>
+                                        <td class="align-middle text-center"><a href=https://issues.redhat.com/browse/{{ card }} target="_blank">{{ card }}</a></td>
+                                        <td class="align-middle"><span class="fw-bold fst-italic">{{ new_comments[account][status][card]['comments'][-1][1][:10] }}</span> - {{ new_comments[account][status][card]['comments'][-1][0] | safe }}</td>
+                                        {% if new_comments[account][status][card]['bugzilla'] and new_comments[account][status][card]['bugzilla'] | length == 1  %}
+                                            <td class="align-middle text-center"><a href={{ new_comments[account][status][card]['bugzilla'][0]['bugzillaLink'] }} target="_blank">{{ new_comments[account][status][card]['bugzilla'][0]['bugzillaNumber'] }}</a></td>
+                                        {% elif new_comments[account][status][card]['bugzilla'] is none%}
+                                            <td class="align-middle text-center">{{ new_comments[account][status][card]['bugzilla'] }}</td>
+                                        {% else %}
+                                            <td class="align-middle text-center">Multiple - Expand for Details</td>
+                                        {% endif %}
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['case_days_open'] }}</td>
+                                        <td class="align-middle text-center">{{ new_comments[account][status][card]['case_updated_date'] }}</td>
+                                    </tr>
+                            {% endfor %}        
+                        {% endfor %}
                     {% endfor %}
-                {% endfor %}
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
 </div>
    <!-- Include jQuery + DataTables -->
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/jquery/dist/jquery.min.js') }}"></script>
@@ -88,6 +90,9 @@
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net-select/js/dataTables.select.min.js') }}"></script>
 
    <script>
+    // Loading Table Message   
+    $('<div class="loading text-center fs-3">Loading Table...</div>').appendTo('#expand-buttons');
+    
     // Insert Bugzilla Info and Comments into Child Rows
     function format(data) {
         let result = "<div class='card p-3'>";
@@ -133,7 +138,7 @@
         return 0;   
     };
 
-    //Initialize DataTable
+    // Initialize DataTable
     $(document).ready(function () {
         let searchOptions = $.fn.dataTable.ext.deepLink([
             'search.search', 'order', 'displayStart'
@@ -158,6 +163,11 @@
                         }
                     }]
                 }]
+            },
+            "initComplete": function(settings, json) {
+                $('div.loading').remove();
+                $('.case-table').show();
+                $($.fn.dataTable.tables(true)).DataTable().columns.adjust();
             }
         };
         let table = $('#data').DataTable($.extend(options, searchOptions));


### PR DESCRIPTION
when viewing a table page on the dashboard, users see the raw HTML table first, then after a few seconds the datatables stuff loads. To avoid confusion and make this cleaner, this PR hides the table and displays `Loading Tables...` until it has fully processed.