### PR TITLE
Fix copy button

### DIFF
--- a/dashboard/src/t5gweb/static/js/refresh.js
+++ b/dashboard/src/t5gweb/static/js/refresh.js
@@ -29,7 +29,7 @@
 /**
  * On page load, get status of most recent background refresh
  * If refresh is in progress, display progress bar and call updatePercentage()
- * to continously update it.
+ * to continuously update it.
  */
  $(document).ready(function () {
     $.ajax({
@@ -55,7 +55,7 @@
 /**
  * getBackground() displays the progress bar when the refresh button is clicked
  * and gets progress information from the task. Also calls updatePercentage()
- * to continously update the progress bar.
+ * to continuously update the progress bar.
  */
 function getBackground() {
     $('#progressbar').empty();

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -77,7 +77,7 @@
                 </svg></a>
             </li>
              <li class="nav-item ms-2">
-                <button type="button" class="btn btn-dark" data-clipboard-target=".copy"><svg alt="Copy" xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" role="img" aria-label="Copy to Clipboard" class="bi bi-clipboard" viewBox="0 0 16 16">
+                <button type="button" class="btn btn-dark" id="copy" data-clipboard-target=".copy"><svg alt="Copy" xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" role="img" aria-label="Copy to Clipboard" class="bi bi-clipboard" viewBox="0 0 16 16">
                    <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>
                    <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
                  </svg></button>
@@ -122,7 +122,7 @@
   
   <!-- Copy Button JS-->
   <script>
-      var clipboard = new ClipboardJS('.btn');
+      var clipboard = new ClipboardJS('#copy');
       clipboard.on('success', function (e) {
          console.log(e);
       });

--- a/dashboard/src/t5gweb/templates/ui/index.html
+++ b/dashboard/src/t5gweb/templates/ui/index.html
@@ -105,15 +105,5 @@
 
     </div>
     </a>
-    <script>
-        var clipboard = new ClipboardJS('.btn');
-        clipboard.on('success', function (e) {
-        console.log(e);
-        });
-
-        clipboard.on('error', function (e) {
-        console.log(e);
-        });
-    </script>
 </div>
   {% endblock %}

--- a/dashboard/src/t5gweb/templates/ui/updates.html
+++ b/dashboard/src/t5gweb/templates/ui/updates.html
@@ -96,14 +96,4 @@
          </div>
       </div>
    </div>
-   <script>
-      var clipboard = new ClipboardJS('.btn');
-      clipboard.on('success', function (e) {
-         console.log(e);
-      });
-
-      clipboard.on('error', function (e) {
-         console.log(e);
-      });
-   </script>
 {% endblock %}

--- a/dashboard/src/t5gweb/templates/ui/weekly_report.html
+++ b/dashboard/src/t5gweb/templates/ui/weekly_report.html
@@ -47,14 +47,4 @@
          </div>
       </div>
    </div>
-   <script>
-      var clipboard = new ClipboardJS('.btn');
-      clipboard.on('success', function (e) {
-         console.log(e);
-      });
-
-      clipboard.on('error', function (e) {
-         console.log(e);
-      });
-   </script>
 {% endblock %}


### PR DESCRIPTION
Previously the copy functionality was being triggered whenever any button on the navbar was clicked. This PR removes duplicate calls of the `ClipboardJS` function and makes the target of the copy function more specific (from `.btn` to `#copy`) to avoid this.