### PR TITLE
Always show filters

### DIFF
--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -170,8 +170,15 @@
                 $('div.loading').remove();
                 $('.case-table').show();
                 $($.fn.dataTable.tables(true)).DataTable().columns.adjust();
-            }
-        };
+            },
+            "columnDefs": [
+                {
+                    searchPanes: {
+                        show: true
+                    },
+                    targets: [9]
+                }
+            ]        };
         let table = $('#data').DataTable($.extend(options, searchOptions));
         table.searchPanes.container().prependTo(table.table().container());
         table.searchPanes.resizePanes();        

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -174,7 +174,7 @@
                     searchPanes: {
                         show: true
                     },
-                    targets: [3, 4, 5, 9]
+                    targets: [3, 4, 5, 9, 11]
                 }
             ]        
         };

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -178,7 +178,8 @@
                     },
                     targets: [9]
                 }
-            ]        };
+            ]        
+        };
         let table = $('#data').DataTable($.extend(options, searchOptions));
         table.searchPanes.container().prependTo(table.table().container());
         table.searchPanes.resizePanes();        

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -176,7 +176,7 @@
                     searchPanes: {
                         show: true
                     },
-                    targets: [9]
+                    targets: [3, 4, 5, 9]
                 }
             ]        
         };


### PR DESCRIPTION
By default, `datatables` will not show filters if its column does not have many unique values. This PR forces all filters to be visible.