### PR TITLE
Avoid picking same engineer twice in a row

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -197,13 +197,9 @@ def get_random_member(team):
 
     last_choice = redis_get('last_choice')
     if len(team) > 1: 
-        if len(last_choice) > 1:
-            while True:
-                current_choice = random.choice(team)
-                if last_choice['name'] != current_choice['name']: 
-                    break
-        else:
-            current_choice = random.choice(team)
+        if last_choice is not None:
+            team = [member for member in team if member != last_choice]
+        current_choice = random.choice(team)
     elif len(team) == 1:
         current_choice = team[0]
     else:

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -193,7 +193,26 @@ def get_case_number(link, pfilter='cases'):
     return ''
 
 def get_random_member(team):
-    return random.choice(team)
+    '''Randomly pick team member and avoid picking the same person twice in a row'''
+
+    last_choice = redis_get('last_choice')
+    if len(team) > 1: 
+        if len(last_choice) > 1:
+            while True:
+                current_choice = random.choice(team)
+                if last_choice['name'] != current_choice['name']: 
+                    break
+        else:
+            current_choice = random.choice(team)
+    elif len(team) == 1:
+        current_choice = team[0]
+    else:
+        logging.warning("No team variable is available, cannot assign case.")
+        current_choice = None
+    redis_set('last_choice', json.dumps(current_choice))
+
+    return current_choice
+
 
 def create_cards(cfg, new_cases, action='none'):
     '''


### PR DESCRIPTION
Per request, change assignment script to avoid randomly selecting the same team member twice in a row.