### PR TITLE
Fix TypeError

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -221,19 +221,16 @@ def create_cards(cfg, new_cases, action='none'):
             redis_set('last_choice', json.dumps(assignee))
         assignee['displayName'] = assignee['name']
         priority = portal2jira_sevs[cases[case]['severity']]
-        full_description = 'This card was automatically created from the Field Engineering Sync Job.\r\n\r\n'
-        + 'This card was created because it had a severity of '
-        + cases[case]['severity']
-        + '\r\n'
-        + 'The account for the case is '
-        + cases[case]['account']
-        + '\r\n'
-        + 'The case had an internal status of: '
-        + cases[case]['status']
-        + '\r\n\r\n'
-        + '*Description:* \r\n\r\n'
-        + cases[case]['description']
-        + '\r\n'
+        full_description = 'This card was automatically created from the Field Engineering Sync Job.\r\n\r\n' + \
+            'This card was created because it had a severity of ' + \
+            cases[case]['severity'] + \
+            '\r\nThe account for the case is ' + \
+            cases[case]['account'] + \
+            '\r\nThe case had an internal status of: ' + \
+            cases[case]['status'] + \
+            '\r\n\r\n*Description:* \r\n\r\n' + \
+            cases[case]['description'] + \
+            '\r\n'
         card_info = {
             'project': {'key': cfg['project']},
             'issuetype': {'name': cfg['type']},


### PR DESCRIPTION
Noticed in the logs that this has been happening for the last few days:
```
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/srv/t5gweb/taskmgr.py", line 147, in portal_jira_sync
    message_content, new_cards = libtelco5g.create_cards(cfg, new_cases, action='create')
  File "/srv/t5gweb/libtelco5g.py", line 225, in create_cards
    + 'This card was created because it had a severity of '
TypeError: bad operand type for unary +: 'str'
```

Perhaps Python got updated and is now mad? Anyway, this PR fixes it
