### PR TITLE
Add basic SAML login mechanism

### DIFF
--- a/dashboard/build/dashboard.sh
+++ b/dashboard/build/dashboard.sh
@@ -12,7 +12,7 @@ if [[ $BASE == "true" ]]; then
   container=$(buildah from registry.fedoraproject.org/fedora:37)
   echo "building container with id $container"
   buildah config --label maintainer="David Critch <dcritch@redhat.com.com>" $container
-  buildah run $container dnf -y install python3-pip gcc redhat-rpm-config python3-devel npm
+  buildah run $container dnf -y install python3-pip gcc redhat-rpm-config python3-devel npm libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
   buildah copy $container ../src/ /srv/
   buildah config --workingdir /srv $container
   buildah run $container pip3 install .

--- a/dashboard/src/setup.py
+++ b/dashboard/src/setup.py
@@ -16,6 +16,8 @@ setup(
         'python_bugzilla==3.2.0',
         'smartsheet-python-sdk==2.177.1',
         'celery==5.2.7',
-        'flower==1.2.0'
+        'flower==1.2.0',
+        'python3-saml==1.15.0',
+        'flask-login==0.6.2'
     ],
 )

--- a/dashboard/src/t5gweb/__init__.py
+++ b/dashboard/src/t5gweb/__init__.py
@@ -9,6 +9,8 @@ def create_app(test_config=None):
     """factory functions to launch app"""
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
+    app.config['SECRET_KEY'] = os.environ.get('secret_key')
+    ui.login_manager.init_app(app)
     #scheduler.init_app(app)
     if test_config is None:
         # load the instance config, if it exists, when not testing

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -20,10 +20,12 @@ from t5gweb.libtelco5g import (
     generate_stats
 )
 import json
+from flask_login import login_required
 
 BP = Blueprint('api', __name__, url_prefix='/api')
 
 @BP.route('/')
+# @login_required
 def index():
     """list api endpoints"""
     endpoints = {"endpoints": [
@@ -45,6 +47,7 @@ def index():
     return endpoints
 
 @BP.route('/refresh/<string:data_type>')
+# @login_required
 def refresh(data_type):
     """Forces an update to the dashboard"""
     cfg = set_cfg()
@@ -72,48 +75,56 @@ def refresh(data_type):
         return {'error': 'unknown data type: {}'.format(data_type)}
 
 @BP.route('/cards')
+# @login_required
 def show_cards():
     """Retrieves all cards"""
     cards = redis_get('cards')
     return cards
 
 @BP.route('/cases')
+# @login_required
 def show_cases():
     """Retrieves all cases"""
     cases = redis_get('cases')
     return cases
     
 @BP.route('/bugs')
+# @login_required
 def show_bugs():
     """Retrieves all bugs"""
     bugs = redis_get('bugs')
     return bugs
 
 @BP.route('/escalations')
+# @login_required
 def show_escalations():
     """Retrieves all escalations"""
     escalations = redis_get('escalations')
     return json.dumps(escalations)
 
 @BP.route('/watchlist')
+# @login_required
 def show_watched():
     """Retrieves all cases on the watchlist"""
     watchlist = redis_get('watchlist')
     return json.dumps(watchlist)
 
 @BP.route('/details')
+# @login_required
 def show_details():
     """Retrieves CritSit and Group Name for each case"""
     details = redis_get('details')
     return json.dumps(details)
 
 @BP.route('/issues')
+# @login_required
 def show_issues():
     """Retrieves all JIRA issues associated with open cases"""
     issues = redis_get('issues')
     return json.dumps(issues)
 
 @BP.route('/stats')
+# @login_required
 def show_stats():
     stats = generate_stats()
     return stats

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -25,7 +25,7 @@ from flask_login import login_required
 BP = Blueprint('api', __name__, url_prefix='/api')
 
 @BP.route('/')
-# @login_required
+@login_required
 def index():
     """list api endpoints"""
     endpoints = {"endpoints": [
@@ -47,7 +47,7 @@ def index():
     return endpoints
 
 @BP.route('/refresh/<string:data_type>')
-# @login_required
+@login_required
 def refresh(data_type):
     """Forces an update to the dashboard"""
     cfg = set_cfg()
@@ -75,56 +75,56 @@ def refresh(data_type):
         return {'error': 'unknown data type: {}'.format(data_type)}
 
 @BP.route('/cards')
-# @login_required
+@login_required
 def show_cards():
     """Retrieves all cards"""
     cards = redis_get('cards')
     return cards
 
 @BP.route('/cases')
-# @login_required
+@login_required
 def show_cases():
     """Retrieves all cases"""
     cases = redis_get('cases')
     return cases
     
 @BP.route('/bugs')
-# @login_required
+@login_required
 def show_bugs():
     """Retrieves all bugs"""
     bugs = redis_get('bugs')
     return bugs
 
 @BP.route('/escalations')
-# @login_required
+@login_required
 def show_escalations():
     """Retrieves all escalations"""
     escalations = redis_get('escalations')
     return json.dumps(escalations)
 
 @BP.route('/watchlist')
-# @login_required
+@login_required
 def show_watched():
     """Retrieves all cases on the watchlist"""
     watchlist = redis_get('watchlist')
     return json.dumps(watchlist)
 
 @BP.route('/details')
-# @login_required
+@login_required
 def show_details():
     """Retrieves CritSit and Group Name for each case"""
     details = redis_get('details')
     return json.dumps(details)
 
 @BP.route('/issues')
-# @login_required
+@login_required
 def show_issues():
     """Retrieves all JIRA issues associated with open cases"""
     issues = redis_get('issues')
     return json.dumps(issues)
 
 @BP.route('/stats')
-# @login_required
+@login_required
 def show_stats():
     stats = generate_stats()
     return stats

--- a/dashboard/src/t5gweb/templates/ui/login.html
+++ b/dashboard/src/t5gweb/templates/ui/login.html
@@ -1,0 +1,28 @@
+{% extends "skeleton.html" %}
+{% block title %}{{ page_title }}{% endblock %}
+{% block content %}
+
+<div class="text-center">
+  <div class="col-xs-12" style="height:50px;"></div>
+  <a href="?sso" class="btn btn-outline-dark mt-5 btn-lg">Login</a>
+  
+  {% if errors %}
+  <div class="alert alert-danger" role="alert">
+    <strong>Errors:</strong>
+    <ul class="list-unstyled">
+        {% for err in errors %}
+          <li>{{err}}</li>
+        {% endfor %}
+    </ul>
+    {% if error_reason %}
+        <span>{{error_reason}}</span>
+    {% endif %}
+  </div>
+{% endif %}
+
+{% if not_auth_warn %}
+  <div class="alert alert-danger" role="alert">Not authenticated</div>
+{% endif %}
+  <div class="col-xs-12" style="height:50px;"></div>
+</div>
+  {% endblock %}

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -164,14 +164,14 @@ def login():
 @BP.route('/stats/telco5g')
 ## end of deprecated routes
 @BP.route('/home')
-# @login_required
+@login_required
 def index():
     """list new cases"""
     load_data()
     return render_template('ui/index.html', new_cases=load_data.new_cases, values=load_data.y, now=load_data.now)
 
 @BP.route('/progress/status', methods=['POST'])
-# @login_required
+@login_required
 def progress_status():
     """On page load: if refresh is in progress, get task information for progress bar display"""
     refresh_id = redis_get('refresh_id')
@@ -181,7 +181,7 @@ def progress_status():
         return jsonify({})
 
 @BP.route('/status/<task_id>')
-# @login_required
+@login_required
 def refresh_status(task_id):
     """Provide updates for refresh_background task"""
     task = refresh_background.AsyncResult(task_id)
@@ -215,7 +215,7 @@ def refresh_status(task_id):
     return jsonify(response)
 
 @BP.route('/refresh', methods=['POST'])
-# @login_required
+@login_required
 def refresh():
     """Forces an update to the dashboard"""
     task = refresh_background.delay()
@@ -224,49 +224,49 @@ def refresh():
 
 
 @BP.route('/updates/')
-# @login_required
+@login_required
 def report_view():
     """Retrieves cards that have been updated within the last week and creates report"""
     load_data()
     return render_template('ui/updates.html', now=load_data.now, new_comments=load_data.accounts, jira_server=load_data.jira_server, page_title='recent updates')
 
 @BP.route('/updates/all')
-# @login_required
+@login_required
 def report_view_all():
     """Retrieves all cards and creates report"""
     load_data()
     return render_template('ui/updates.html', now=load_data.now, new_comments=load_data.accounts_all, jira_server=load_data.jira_server, page_title='all cards')
 
 @BP.route('/trends/')
-# @login_required
+@login_required
 def trends():
     """Retrieves cards that have been labeled with 'Trends' within the previous quarter and creates report"""
     load_data()
     return render_template('ui/updates.html', now=load_data.now, new_comments=load_data.trending_cards, jira_server=load_data.jira_server, page_title='trends')
 
 @BP.route('/table/')
-# @login_required
+@login_required
 def table_view():
     """Sorts new cards by severity and creates table"""
     load_data()
     return render_template('ui/table.html', now=load_data.now, new_comments=load_data.accounts, jira_server=load_data.jira_server, page_title='severity')
 
 @BP.route('/table/all')
-# @login_required
+@login_required
 def table_view_all():
     """Sorts all cards by severity and creates table"""
     load_data()
     return render_template('ui/table.html', now=load_data.now, new_comments=load_data.accounts_all, jira_server=load_data.jira_server, page_title='all-severity')
 
 @BP.route('/weekly/')
-# @login_required
+@login_required
 def weekly_updates():
     """Retrieves cards and displays them plainly for easy copy/pasting and distribution"""
     load_data()
     return render_template('ui/weekly_report.html', now=load_data.now, new_comments=load_data.accounts, jira_server=load_data.jira_server, page_title='weekly-update')
 
 @BP.route('/stats')
-# @login_required
+@login_required
 def get_stats():
     """ generate some stats"""
     load_data()
@@ -275,7 +275,7 @@ def get_stats():
     return render_template('ui/stats.html', now=load_data.now, stats=stats, x_values=x_values, y_values=y_values, page_title='stats')
     
 @BP.route('/account/<string:account>')
-# @login_required
+@login_required
 def get_account(account):
     '''show bugs, cases and stats by for a given account'''
     load_data()

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -1,8 +1,10 @@
 """UI views for t5gweb"""
-import logging
-import datetime
+# The login code was derived from https://github.com/SAML-Toolkits/python3-saml/tree/master/demo-flask
+# License - https://github.com/SAML-Toolkits/python3-saml/blob/master/LICENSE
+import os
+import json
 from flask import (
-    Blueprint, jsonify, redirect, render_template, request, url_for, make_response, send_file, request
+    Blueprint, jsonify, redirect, render_template, request, url_for, make_response, session, request, abort
 )
 from t5gweb.taskmgr import refresh_background
 from t5gweb.t5gweb import (
@@ -13,6 +15,7 @@ from t5gweb.t5gweb import (
 )
 from t5gweb.libtelco5g import(
     redis_get,
+    redis_set,
     generate_stats,
     plot_stats
 )
@@ -20,7 +23,55 @@ from t5gweb.utils import (
     set_cfg
 )
 
+from urllib.parse import urlparse, urljoin
+from flask_login import LoginManager, UserMixin, login_user, login_required
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
+
 BP = Blueprint('ui', __name__, url_prefix='/')
+login_manager=LoginManager()
+login_manager.login_view = 'ui.login'
+users = redis_get('users')
+
+class User(UserMixin):
+    def __init__(self, user_id):
+        user = users[user_id]
+        self.id = user_id
+        self.given_name = user['givenName'][0]
+        self.mail = user['mail'][0]
+
+def is_safe_url(target):
+    '''From https://flask-login.readthedocs.io/en/latest/#login-example, prevents Open Redirects'''
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(urljoin(request.host_url, target))
+    return test_url.scheme in ('http', 'https') and \
+           ref_url.netloc == test_url.netloc
+
+@login_manager.user_loader
+def load_user(user_id):
+    '''https://flask-login.readthedocs.io/en/latest/#how-it-works'''
+    if user_id in users:
+        return User(user_id)
+    return None
+
+def init_saml_auth(req):
+    '''Load user-configured settings into SAML package'''
+    settings = json.loads(os.environ.get('saml_settings'))
+    auth = OneLogin_Saml2_Auth(req, settings)
+    return auth
+
+
+def prepare_flask_request(request):
+    # If server is behind proxys or balancers use the HTTP_X_FORWARDED fields
+    return {
+        'https': 'on',
+        'http_host': request.host,
+        'script_name': request.path,
+        'get_data': request.args.copy(),
+        # Uncomment if using ADFS as IdP, https://github.com/onelogin/python-saml/pull/144
+        # 'lowercase_urlencoding': True,
+        'post_data': request.form.copy()
+    }
 
 def load_data():
     """Load data for dashboard"""
@@ -35,6 +86,70 @@ def load_data():
     load_data.now = redis_get('timestamp')
     load_data.jira_server = cfg['server']
 
+@BP.route('/', methods=['GET', 'POST'])
+def login():
+    '''Handles redirects back and forth from SAML Provider and user creation in Redis'''
+    req = prepare_flask_request(request)
+    auth = init_saml_auth(req)
+    errors = []
+    error_reason = None
+    not_auth_warn = False
+    attributes = False
+
+    if 'sso' in request.args:
+        return redirect(auth.login())
+    elif 'acs' in request.args:
+        request_id = None
+        if 'AuthNRequestID' in session:
+            request_id = session['AuthNRequestID']
+
+        auth.process_response(request_id=request_id)
+        errors = auth.get_errors()
+        not_auth_warn = not auth.is_authenticated()
+        if len(errors) == 0:
+            if 'AuthNRequestID' in session:
+                del session['AuthNRequestID']
+            session['samlUserdata'] = auth.get_attributes()
+            session['samlNameId'] = auth.get_nameid()
+            session['samlNameIdFormat'] = auth.get_nameid_format()
+            session['samlNameIdNameQualifier'] = auth.get_nameid_nq()
+            session['samlNameIdSPNameQualifier'] = auth.get_nameid_spnq()
+            session['samlSessionIndex'] = auth.get_session_index()
+            self_url = OneLogin_Saml2_Utils.get_self_url(req)
+            if 'RelayState' in request.form and self_url != request.form['RelayState']:
+                # To avoid 'Open Redirect' attacks, before execute the redirection confirm
+                # the value of the request.form['RelayState'] is a trusted URL.
+                if not is_safe_url(request.form['RelayState']):
+                    abort(400)
+                return redirect(auth.redirect_to(request.form['RelayState']))
+        elif auth.get_settings().is_debug_active():
+            error_reason = auth.get_last_error_reason()
+    if 'samlUserdata' in session:
+        if len(session['samlUserdata']) > 0:
+            attributes = session['samlUserdata']
+        
+        #JIT Provisioning
+        if attributes['rhatUUID'][0] not in users:
+            new_user = {attributes['rhatUUID'][0]: {attribute_name:attribute_value for (attribute_name,attribute_value) in attributes.items()}}
+            users.update(new_user)
+            redis_set('users',json.dumps(users))
+
+        user = User(attributes['rhatUUID'][0])
+        login_user(user)
+        next = request.args.get('next')
+
+        # Avoid 'Open Redirect'
+        if not is_safe_url(next):
+            return abort(400)
+        return redirect(next or url_for('ui.index'))
+
+
+    return render_template(
+        'ui/login.html',
+        errors=errors,
+        error_reason=error_reason,
+        not_auth_warn=not_auth_warn,
+    )
 
 ## deprecated endpoints to remove
 @BP.route('/updates/telco5g')
@@ -48,13 +163,15 @@ def load_data():
 @BP.route('/stats/cnv')
 @BP.route('/stats/telco5g')
 ## end of deprecated routes
-@BP.route('/')
+@BP.route('/home')
+# @login_required
 def index():
     """list new cases"""
     load_data()
     return render_template('ui/index.html', new_cases=load_data.new_cases, values=load_data.y, now=load_data.now)
 
 @BP.route('/progress/status', methods=['POST'])
+# @login_required
 def progress_status():
     """On page load: if refresh is in progress, get task information for progress bar display"""
     refresh_id = redis_get('refresh_id')
@@ -64,6 +181,7 @@ def progress_status():
         return jsonify({})
 
 @BP.route('/status/<task_id>')
+# @login_required
 def refresh_status(task_id):
     """Provide updates for refresh_background task"""
     task = refresh_background.AsyncResult(task_id)
@@ -97,6 +215,7 @@ def refresh_status(task_id):
     return jsonify(response)
 
 @BP.route('/refresh', methods=['POST'])
+# @login_required
 def refresh():
     """Forces an update to the dashboard"""
     task = refresh_background.delay()
@@ -105,42 +224,49 @@ def refresh():
 
 
 @BP.route('/updates/')
+# @login_required
 def report_view():
     """Retrieves cards that have been updated within the last week and creates report"""
     load_data()
     return render_template('ui/updates.html', now=load_data.now, new_comments=load_data.accounts, jira_server=load_data.jira_server, page_title='recent updates')
 
 @BP.route('/updates/all')
+# @login_required
 def report_view_all():
     """Retrieves all cards and creates report"""
     load_data()
     return render_template('ui/updates.html', now=load_data.now, new_comments=load_data.accounts_all, jira_server=load_data.jira_server, page_title='all cards')
 
 @BP.route('/trends/')
+# @login_required
 def trends():
     """Retrieves cards that have been labeled with 'Trends' within the previous quarter and creates report"""
     load_data()
     return render_template('ui/updates.html', now=load_data.now, new_comments=load_data.trending_cards, jira_server=load_data.jira_server, page_title='trends')
 
 @BP.route('/table/')
+# @login_required
 def table_view():
     """Sorts new cards by severity and creates table"""
     load_data()
     return render_template('ui/table.html', now=load_data.now, new_comments=load_data.accounts, jira_server=load_data.jira_server, page_title='severity')
 
 @BP.route('/table/all')
+# @login_required
 def table_view_all():
     """Sorts all cards by severity and creates table"""
     load_data()
     return render_template('ui/table.html', now=load_data.now, new_comments=load_data.accounts_all, jira_server=load_data.jira_server, page_title='all-severity')
 
 @BP.route('/weekly/')
+# @login_required
 def weekly_updates():
     """Retrieves cards and displays them plainly for easy copy/pasting and distribution"""
     load_data()
     return render_template('ui/weekly_report.html', now=load_data.now, new_comments=load_data.accounts, jira_server=load_data.jira_server, page_title='weekly-update')
 
 @BP.route('/stats')
+# @login_required
 def get_stats():
     """ generate some stats"""
     load_data()
@@ -149,6 +275,7 @@ def get_stats():
     return render_template('ui/stats.html', now=load_data.now, stats=stats, x_values=x_values, y_values=y_values, page_title='stats')
     
 @BP.route('/account/<string:account>')
+# @login_required
 def get_account(account):
     '''show bugs, cases and stats by for a given account'''
     load_data()


### PR DESCRIPTION
- Create basic user db in `redis` so that `flask-login` can manage users.
- Create login page and mechanism so that users can authenticate w/ SSO before viewing information

I've left `@login.required` commented out for the time being in `dashboard/src/t5gweb/ui.py` to make sure all pages are still accessible w/o login. This way, we can verify that SAML is working w/o inadvertently locking everyone out. Once we confirm that it's working, we can uncomment these decorators.