### PR TITLE
Add links to table for prio-list Cases

### DIFF
--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -211,9 +211,9 @@ def get_cards(cfg, self=None, background=False):
             escalated = False
         
         if 'PotentialEscalation' in issue.fields.labels and escalated is False:
-            potenial_escalation = True
+            potential_escalation = True
         else:
-            potenial_escalation = False
+            potential_escalation = False
 
         if watchlist and case_number in watchlist:
             watched = True
@@ -243,7 +243,7 @@ def get_cards(cfg, self=None, background=False):
             "severity": re.search(r'[a-zA-Z]+', cases[case_number]['severity']).group(),
             "priority": issue.fields.priority.name,
             "escalated": escalated,
-            "potenial_escalation": potenial_escalation,
+            "potential_escalation": potential_escalation,
             "watched": watched,
             "product": cases[case_number]['product'],
             "case_status": cases[case_number]['status'],

--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -209,7 +209,15 @@ def get_cards(cfg, self=None, background=False):
             escalated = True
         else:
             escalated = False
-        
+        if case_issues:
+            for case_issue in case_issues:
+                if cfg['jira_escalations_project'] in case_issue['id']:
+                    escalated_link = case_issue['url']
+                    break
+                else:
+                    escalated_link = None
+        else:
+            escalated_link = None
         if 'PotentialEscalation' in issue.fields.labels and escalated is False:
             potential_escalation = True
         else:
@@ -243,6 +251,7 @@ def get_cards(cfg, self=None, background=False):
             "severity": re.search(r'[a-zA-Z]+', cases[case_number]['severity']).group(),
             "priority": issue.fields.priority.name,
             "escalated": escalated,
+            "escalated_link": escalated_link,
             "potential_escalation": potential_escalation,
             "watched": watched,
             "product": cases[case_number]['product'],

--- a/dashboard/src/t5gweb/static/js/table.js
+++ b/dashboard/src/t5gweb/static/js/table.js
@@ -84,7 +84,7 @@ $(document).ready(function () {
                         {
                             label: 'Yes',
                             value: function (rowData, rowIdx) {
-                                return rowData[3] == 'Yes';
+                                return rowData[3].includes("Yes");
                             }
                         }
                     ]

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -100,7 +100,7 @@
   <div class="footer">
     {% block footer %}
     <div class=left>
-      Maintainted by the Telco5G Field Engineering Team
+      Maintained by the Telco5G Field Engineering Team
     </div>
     <a href="https://github.com/RHsyseng/t5g-field-support-team-utils" target="_blank">t5g-field-support-team-utils</a>
     {% endblock %}

--- a/dashboard/src/t5gweb/templates/ui/account.html
+++ b/dashboard/src/t5gweb/templates/ui/account.html
@@ -283,7 +283,7 @@
                                 <td data-order="{{ severity_order }}" class="align-middle text-center"><span class="badge severity {{ new_comments[account][status][card]['severity'] | lower() }}">{{ new_comments[account][status][card]['severity'] }}</span></td>
                                 {% if new_comments[account][status][card]['escalated'] %}
                                     <td class="align-middle text-center">Yes</td>
-                                {% elif new_comments[account][status][card]['potenial_escalation'] %}
+                                {% elif new_comments[account][status][card]['potential_escalation'] %}
                                     <td class="align-middle text-center">Potentially</td>
                                 {% else %}
                                     <td class="align-middle text-center">No</td>

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -51,7 +51,7 @@
                                 <td data-order="{{ severity_order }}" class="align-middle text-center"><span class="badge severity {{ new_comments[account][status][card]['severity'] | lower() }}">{{ new_comments[account][status][card]['severity'] }}</span></td>
                                 {% if new_comments[account][status][card]['escalated'] %}
                                     <td class="align-middle text-center">Yes</td>
-                                {% elif new_comments[account][status][card]['potenial_escalation'] %}
+                                {% elif new_comments[account][status][card]['potential_escalation'] %}
                                     <td class="align-middle text-center">Potentially</td>
                                 {% else %}
                                     <td class="align-middle text-center">No</td>

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -50,7 +50,11 @@
                                 <td class="align-middle text-center"><a href=https://access.redhat.com/support/cases/#/case/{{new_comments[account][status][card]['case_number'] }} target="_blank">{{ new_comments[account][status][card]['case_number'] }}</a></td>
                                 <td data-order="{{ severity_order }}" class="align-middle text-center"><span class="badge severity {{ new_comments[account][status][card]['severity'] | lower() }}">{{ new_comments[account][status][card]['severity'] }}</span></td>
                                 {% if new_comments[account][status][card]['escalated'] %}
-                                    <td class="align-middle text-center">Yes</td>
+                                    {% if new_comments[account][status][card]['escalated_link'] %}
+                                        <td class="align-middle text-center"><a href="{{new_comments[account][status][card]['escalated_link']}}">Yes</a></td>
+                                    {% else %}
+                                        <td class="align-middle text-center">Yes</td>
+                                    {% endif %}
                                 {% elif new_comments[account][status][card]['potential_escalation'] %}
                                     <td class="align-middle text-center">Potentially</td>
                                 {% else %}


### PR DESCRIPTION
If a case is on the prio-list and it has a linked issue that is part of the `jira_escalations_project`, the word `Yes` will be hyperlinked in the `On prio-list?` column. Also accounts for this change in the filters above the table, and fixes a misspelled variable.