### PR TITLE
Add relief and resolutions charts to account and stats pages.

### DIFF
--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -191,9 +191,16 @@ def get_cards(cfg, self=None, background=False):
         if case_number in details.keys():
             crit_sit = details[case_number]['crit_sit']
             group_name = details[case_number]['group_name']
+            notified_users = details[case_number]['notified_users']
+            relief_at = details[case_number]['relief_at']
+            resolved_at = details[case_number]['resolved_at']
+
         else:
             crit_sit = False
             group_name = None
+            notified_users = []
+            relief_at = None
+            resolved_at = None
 
         jira_cards[card.key] = {
             "card_status": libtelco5g.status_map[issue.fields.status.name],
@@ -220,7 +227,11 @@ def get_cards(cfg, self=None, background=False):
             "crit_sit": crit_sit,
             "group_name": group_name,
             "case_updated_date": datetime.datetime.strftime(datetime.datetime.strptime(cases[case_number]['last_update'], '%Y-%m-%dT%H:%M:%SZ'), '%Y-%m-%d %H:%M'),
-            "case_days_open": (time_now.replace(tzinfo=None) - datetime.datetime.strptime(cases[case_number]['createdate'], '%Y-%m-%dT%H:%M:%SZ')).days
+            "case_days_open": (time_now.replace(tzinfo=None) - datetime.datetime.strptime(cases[case_number]['createdate'], '%Y-%m-%dT%H:%M:%SZ')).days,
+            "case_created": cases[case_number]['createdate'],
+            "notified_users": notified_users,
+            "relief_at": relief_at,
+            "resolved_at": resolved_at
         }
 
     end = time.time()
@@ -278,11 +289,15 @@ def get_case_details(cfg):
             crit_sit = r_case.json().get('critSit', False)
             group_name = r_case.json().get('groupName', None)
             notified_users = r_case.json().get('notifiedUsers', [])
+            relief_at = r_case.json().get('reliefAt', None)
+            resolved_at = r_case.json().get('resolvedAt', None)
 
             case_details[case] = {
                 "crit_sit": crit_sit,
                 "group_name": group_name,
-                "notified_users": notified_users
+                "notified_users": notified_users,
+                "relief_at": relief_at,
+                "resolved_at": resolved_at
             }
             if "bug" in cases[case]:
                 bz_dict[case] = r_case.json()['bugzillas']

--- a/dashboard/src/t5gweb/static/package-lock.json
+++ b/dashboard/src/t5gweb/static/package-lock.json
@@ -1,113 +1,145 @@
 {
   "name": "t5gweb",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@popperjs/core": {
+  "packages": {
+    "": {
+      "name": "t5gweb",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@popperjs/core": "^2.11.4",
+        "bootstrap": "^5.1.3",
+        "chart.js": "^3.7.1",
+        "clipboard": "^2.0.10",
+        "datatables.net": "^1.11.5",
+        "datatables.net-bs5": "^1.11.5",
+        "datatables.net-searchpanes-bs5": "^2.0.0",
+        "datatables.net-select-bs5": "^1.3.4",
+        "plotly.js-cartesian-dist-min": "^2.24.2"
+      }
+    },
+    "node_modules/@popperjs/core": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
-      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg=="
+      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
-    "bootstrap": {
+    "node_modules/bootstrap": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q=="
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.10.2"
+      }
     },
-    "chart.js": {
+    "node_modules/chart.js": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.1.tgz",
       "integrity": "sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA=="
     },
-    "clipboard": {
+    "node_modules/clipboard": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.10.tgz",
       "integrity": "sha512-cz3m2YVwFz95qSEbCDi2fzLN/epEN9zXBvfgAoGkvGOJZATMl9gtTDVOtBYkx2ODUJl2kvmud7n32sV2BpYR4g==",
-      "requires": {
+      "dependencies": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
         "tiny-emitter": "^2.0.0"
       }
     },
-    "datatables.net": {
+    "node_modules/datatables.net": {
       "version": "1.11.5",
       "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.11.5.tgz",
       "integrity": "sha512-nlFst2xfwSWaQgaOg5sXVG3cxYC0tH8E8d65289w9ROgF2TmLULOOpcdMpyxxUim/qEwVSEem42RjkTWEpr3eA==",
-      "requires": {
+      "dependencies": {
         "jquery": ">=1.7"
       }
     },
-    "datatables.net-bs5": {
+    "node_modules/datatables.net-bs5": {
       "version": "1.11.5",
       "resolved": "https://registry.npmjs.org/datatables.net-bs5/-/datatables.net-bs5-1.11.5.tgz",
       "integrity": "sha512-1zyh972GtuK1uAb9h8nP3jJ7f/3UgCDq69LAaZS2bVd4mEHECJ6vrZLacxrkOHOs/q/H3v5sEMeZ46vXz8ox4w==",
-      "requires": {
+      "dependencies": {
         "datatables.net": ">=1.11.3",
         "jquery": ">=1.7"
       }
     },
-    "datatables.net-searchpanes": {
+    "node_modules/datatables.net-searchpanes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/datatables.net-searchpanes/-/datatables.net-searchpanes-2.0.0.tgz",
       "integrity": "sha512-SWwbLPlavuOerDLaq9CqYG1GXm7BsWWd0c7Qs8nD/P7k69xZ4fMNbDZSIhz8PJ6zT9KLMHwCW4s+VooCMBf0Xw==",
-      "requires": {
+      "dependencies": {
         "datatables.net": ">=1.11.3",
         "jquery": ">=1.7"
       }
     },
-    "datatables.net-searchpanes-bs5": {
+    "node_modules/datatables.net-searchpanes-bs5": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/datatables.net-searchpanes-bs5/-/datatables.net-searchpanes-bs5-2.0.0.tgz",
       "integrity": "sha512-kK5t1P+4xtR3RjEdRBIBOCFu7Pvmn5cOWqkYDYrc/Gz7MBO6YfrNkJFhyJc2qJZ3VcRTrsCoNmRCt7rmQedv4w==",
-      "requires": {
+      "dependencies": {
         "datatables.net-bs5": ">=1.11.3",
         "datatables.net-searchpanes": ">=1.4.0",
         "jquery": ">=1.7"
       }
     },
-    "datatables.net-select": {
+    "node_modules/datatables.net-select": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.3.4.tgz",
       "integrity": "sha512-iQ/dBHIWkhfCBxzNdtef79seCNO1ZsA5zU0Uiw3R2mlwmjcJM1xn6pFNajke6SX7VnlzndGDHGqzzEljSqz4pA==",
-      "requires": {
+      "dependencies": {
         "datatables.net": ">=1.11.3",
         "jquery": ">=1.7"
       }
     },
-    "datatables.net-select-bs5": {
+    "node_modules/datatables.net-select-bs5": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/datatables.net-select-bs5/-/datatables.net-select-bs5-1.3.4.tgz",
       "integrity": "sha512-fJyFVtDzo4P4oIOUU2vSvYLuegDdSoqJrqPbFaI0DX2O/MYg2H9hXo09UZ7No/pxBJ1NBRCm8Q3U9uyoCBK7RQ==",
-      "requires": {
+      "dependencies": {
         "datatables.net-bs5": ">=1.11.3",
         "datatables.net-select": ">=1.3.3",
         "jquery": ">=1.7"
       }
     },
-    "delegate": {
+    "node_modules/delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
-    "good-listener": {
+    "node_modules/good-listener": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "requires": {
+      "dependencies": {
         "delegate": "^3.1.2"
       }
     },
-    "jquery": {
+    "node_modules/jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
-    "select": {
+    "node_modules/plotly.js-cartesian-dist-min": {
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/plotly.js-cartesian-dist-min/-/plotly.js-cartesian-dist-min-2.24.2.tgz",
+      "integrity": "sha512-8uaRSjPZygFMZqc17r57kthr72oyWN3wFePeLlmYG/JzxmiitlPQhhPK+XwY+RWl/6LYGGuQ0HIBtrO2gtFHbw=="
+    },
+    "node_modules/select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
-    "tiny-emitter": {
+    "node_modules/tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="

--- a/dashboard/src/t5gweb/static/package.json
+++ b/dashboard/src/t5gweb/static/package.json
@@ -24,6 +24,7 @@
     "datatables.net": "^1.11.5",
     "datatables.net-bs5": "^1.11.5",
     "datatables.net-searchpanes-bs5": "^2.0.0",
-    "datatables.net-select-bs5": "^1.3.4"
+    "datatables.net-select-bs5": "^1.3.4",
+    "plotly.js-cartesian-dist-min": "^2.24.2"
   }
 }

--- a/dashboard/src/t5gweb/templates/ui/account.html
+++ b/dashboard/src/t5gweb/templates/ui/account.html
@@ -10,6 +10,8 @@
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net-searchpanes-bs5/js/searchPanes.bootstrap5.min.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net-select/js/dataTables.select.min.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='js/table.js') }}"></script>
+   <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/plotly.js-cartesian-dist-min/plotly-cartesian.min.js') }}"></script>
+
 <div class="container-fluid copy mt-5">
     <h2>Account Stats: {{account}} </h2>
     <div class="row">
@@ -68,6 +70,97 @@
                     <td class="align-middle text-center">{{ stats['bugs']['no_target'] }}</td>
         </tbody>
         </table>
+        <div class="row">
+            <div class="col">
+                <div class="card mx-auto">
+                    <div class="card-body">
+                        <div id="reliefHistogram"></div>
+                        <div class="container pt-3 pb-5">
+                            <h2>Statistics</h2>
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>Urgent</th>
+                                        <th>High</th>
+                                        <th>Normal</th>
+                                        <th>Low</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>Average Time Until Relief (Days)</td>
+                                        <td id="avg1"></td>
+                                        <td id="avg2"></td>
+                                        <td id="avg3"></td>
+                                        <td id="avg4"></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Median Time Until Relief (Days)</td>
+                                        <td id="median1"></td>
+                                        <td id="median2"></td>
+                                        <td id="median3"></td>
+                                        <td id="median4"></td>
+                                    </tr>
+                                    <tr>
+                                        <td># of Cases</td>
+                                        <td id="cases1"></td>
+                                        <td id="cases2"></td>
+                                        <td id="cases3"></td>
+                                        <td id="cases4"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+        
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mx-auto">
+                    <div class="card-body">
+                        <div id="resolutionHistogram"></div>
+                        <div class="container pt-3 pb-5">
+                            <h2>Statistics</h2>
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>Urgent</th>
+                                        <th>High</th>
+                                        <th>Normal</th>
+                                        <th>Low</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>Average Time Until Resolution (Days)</td>
+                                        <td id="avg5"></td>
+                                        <td id="avg6"></td>
+                                        <td id="avg7"></td>
+                                        <td id="avg8"></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Median Time Until Resolution (Days)</td>
+                                        <td id="median5"></td>
+                                        <td id="median6"></td>
+                                        <td id="median7"></td>
+                                        <td id="median8"></td>
+                                    </tr>
+                                    <tr>
+                                        <td># of Cases</td>
+                                        <td id="cases5"></td>
+                                        <td id="cases6"></td>
+                                        <td id="cases7"></td>
+                                        <td id="cases8"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
         </div>
         <div class="col-12 col-sm-6">
             <div class="card mb-2">
@@ -322,8 +415,150 @@
             </tbody>
         </table>
     </div>
-
-   
-
 </div>
+<script>
+    // Create the histograms
+    var reliefUrgent = {
+        x: {{ histogram_stats["Relief"]["Urgent"] | safe }},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'Urgent'
+    };
+
+    var reliefHigh = {
+        x: {{ histogram_stats["Relief"]["High"] | safe}},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'High'
+    };
+
+    var reliefNormal = {
+        x: {{ histogram_stats["Relief"]["Normal"] | safe}},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'Normal'
+    };
+
+    var reliefLow = {
+        x: {{ histogram_stats["Relief"]["Low"] | safe}},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'Low'
+    };
+
+    var reliefLayout = {
+        barmode: 'overlay',
+        title: 'Time to Relief',
+        xaxis: { title: 'Days From Case Creation Until Relief' },
+        yaxis: { title: 'Frequency' }
+    };
+
+    var reliefData = [reliefUrgent, reliefHigh, reliefNormal, reliefLow];
+    Plotly.newPlot('reliefHistogram', reliefData, reliefLayout, { responsive: true });
+
+    var resolutionUrgent = {
+        x: {{ histogram_stats["Resolved"]["Urgent"] | safe }},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'Urgent'
+    };
+
+    var resolutionHigh = {
+        x: {{ histogram_stats["Resolved"]["High"] | safe}},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'High'
+    };
+
+    var resolutionNormal = {
+        x: {{ histogram_stats["Resolved"]["Normal"] | safe }},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'Normal'
+    };
+
+    var resolutionLow = {
+        x: {{ histogram_stats["Resolved"]["Low"] | safe}},
+        type: 'histogram',
+        opacity: 0.5,
+        name: 'Low'
+    };
+
+    var resolutionLayout = {
+        barmode: 'overlay',
+        title: 'Time to Resolution',
+        xaxis: { title: 'Days From Case Creation Until Resolution' },
+        yaxis: { title: 'Frequency' }
+    };
+
+    var resolutionData = [resolutionUrgent, resolutionHigh, resolutionNormal, resolutionLow];
+    Plotly.newPlot('resolutionHistogram', resolutionData, resolutionLayout, { responsive: true });
+
+    // Update table values
+    function median(values) {
+        if (values.length === 0) {
+            return 0;
+        }
+        // Sort the array in ascending order
+        const sortedNumbers = values.sort((a, b) => a - b);
+
+        // Calculate the median
+        let median;
+        const middleIndex = Math.floor(sortedNumbers.length / 2);
+
+        if (sortedNumbers.length % 2 === 0) {
+            // Even length array
+            median = (sortedNumbers[middleIndex - 1] + sortedNumbers[middleIndex]) / 2;
+        } else {
+            // Odd length array
+            median = sortedNumbers[middleIndex];
+        }
+
+        return median;
+    }
+
+    function average(values) {
+        if (values.length === 0) {
+            return 0;
+        }
+        let sum = 0;
+        for (let i = 0; i < values.length; i++) {
+            sum += values[i];
+        }
+        return sum / values.length;
+    }
+    function updateTable() {
+        document.getElementById("avg1").textContent = average({{ histogram_stats["Relief"]["Urgent"] | safe }}).toFixed(1);
+        document.getElementById("avg2").textContent = average({{ histogram_stats["Relief"]["High"] | safe }}).toFixed(1);
+        document.getElementById("avg3").textContent = average({{ histogram_stats["Relief"]["Normal"] | safe }}).toFixed(1);
+        document.getElementById("avg4").textContent = average({{ histogram_stats["Relief"]["Low"] | safe }}).toFixed(1);
+        document.getElementById("avg5").textContent = average({{ histogram_stats["Resolved"]["Urgent"] | safe }}).toFixed(1);
+        document.getElementById("avg6").textContent = average({{ histogram_stats["Resolved"]["High"] | safe }}).toFixed(1);
+        document.getElementById("avg7").textContent = average({{ histogram_stats["Resolved"]["Normal"] | safe }}).toFixed(1);
+        document.getElementById("avg8").textContent = average({{ histogram_stats["Resolved"]["Low"] | safe }}).toFixed(1);
+
+
+        document.getElementById("median1").textContent = median({{ histogram_stats["Relief"]["Urgent"] | safe }}).toFixed(1);
+        document.getElementById("median2").textContent = median({{ histogram_stats["Relief"]["High"] | safe }}).toFixed(1);
+        document.getElementById("median3").textContent = median({{ histogram_stats["Relief"]["Normal"] | safe }}).toFixed(1);
+        document.getElementById("median4").textContent = median({{ histogram_stats["Relief"]["Low"] | safe }}).toFixed(1);
+        document.getElementById("median5").textContent = median({{ histogram_stats["Resolved"]["Urgent"] | safe }}).toFixed(1);
+        document.getElementById("median6").textContent = median({{ histogram_stats["Resolved"]["High"] | safe }}).toFixed(1);
+        document.getElementById("median7").textContent = median({{ histogram_stats["Resolved"]["Normal"] | safe }}).toFixed(1);
+        document.getElementById("median8").textContent = median({{ histogram_stats["Resolved"]["Low"] | safe }}).toFixed(1);
+
+        document.getElementById("cases1").textContent = {{ histogram_stats["Relief"]["Urgent"] | safe }}.length;
+        document.getElementById("cases2").textContent = {{ histogram_stats["Relief"]["High"] | safe }}.length;
+        document.getElementById("cases3").textContent = {{ histogram_stats["Relief"]["Normal"] | safe }}.length;
+        document.getElementById("cases4").textContent = {{ histogram_stats["Relief"]["Low"] | safe }}.length;
+        document.getElementById("cases5").textContent = {{ histogram_stats["Resolved"]["Urgent"] | safe }}.length;
+        document.getElementById("cases6").textContent = {{ histogram_stats["Resolved"]["High"] | safe }}.length;
+        document.getElementById("cases7").textContent = {{ histogram_stats["Resolved"]["Normal"] | safe }}.length;
+        document.getElementById("cases8").textContent = {{ histogram_stats["Resolved"]["Low"] | safe }}.length;
+
+    }
+
+    // Initial table update
+    updateTable();
+</script>
 {% endblock %}

--- a/dashboard/src/t5gweb/templates/ui/stats.html
+++ b/dashboard/src/t5gweb/templates/ui/stats.html
@@ -6,6 +6,7 @@
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net/js/jquery.dataTables.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/datatables.net-bs5/js/dataTables.bootstrap5.min.js') }}"></script>
    <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='js/plugins.js') }}"></script>
+   <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='node_modules/plotly.js-cartesian-dist-min/plotly-cartesian.min.js') }}"></script>
 
 <div class="container-fluid copy mt-5">
     <h2>Overall Stats:</h2>
@@ -216,8 +217,244 @@
                         {% endfor %}
                 </tbody>
             </table>
-        </div>  
+            <div class="row">
+                <div class="col">
+                    <div class="card mx-auto">
+                        <div class="card-body">
+                            <div id="reliefHistogram"></div>
+                            <div class="container pt-3 pb-5">
+                                <h2>Statistics</h2>
+                                <table class="table">
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th>Urgent</th>
+                                            <th>High</th>
+                                            <th>Normal</th>
+                                            <th>Low</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Average Time Until Relief (Days)</td>
+                                            <td id="avg1"></td>
+                                            <td id="avg2"></td>
+                                            <td id="avg3"></td>
+                                            <td id="avg4"></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Median Time Until Relief (Days)</td>
+                                            <td id="median1"></td>
+                                            <td id="median2"></td>
+                                            <td id="median3"></td>
+                                            <td id="median4"></td>
+                                        </tr>
+                                        <tr>
+                                            <td># of Cases</td>
+                                            <td id="cases1"></td>
+                                            <td id="cases2"></td>
+                                            <td id="cases3"></td>
+                                            <td id="cases4"></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+            
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card mx-auto">
+                        <div class="card-body">
+                            <div id="resolutionHistogram"></div>
+                            <div class="container pt-3 pb-5">
+                                <h2>Statistics</h2>
+                                <table class="table">
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th>Urgent</th>
+                                            <th>High</th>
+                                            <th>Normal</th>
+                                            <th>Low</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Average Time Until Resolution (Days)</td>
+                                            <td id="avg5"></td>
+                                            <td id="avg6"></td>
+                                            <td id="avg7"></td>
+                                            <td id="avg8"></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Median Time Until Resolution (Days)</td>
+                                            <td id="median5"></td>
+                                            <td id="median6"></td>
+                                            <td id="median7"></td>
+                                            <td id="median8"></td>
+                                        </tr>
+                                        <tr>
+                                            <td># of Cases</td>
+                                            <td id="cases5"></td>
+                                            <td id="cases6"></td>
+                                            <td id="cases7"></td>
+                                            <td id="cases8"></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
+<script>
+        // Create the histograms
+        var reliefUrgent = {
+            x: {{ histogram_stats["Relief"]["Urgent"] | safe }},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'Urgent'
+        };
+
+        var reliefHigh = {
+            x: {{ histogram_stats["Relief"]["High"] | safe}},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'High'
+        };
+
+        var reliefNormal = {
+            x: {{ histogram_stats["Relief"]["Normal"] | safe}},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'Normal'
+        };
+
+        var reliefLow = {
+            x: {{ histogram_stats["Relief"]["Low"] | safe}},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'Low'
+        };
+
+        var reliefLayout = {
+            barmode: 'overlay',
+            title: 'Time to Relief',
+            xaxis: { title: 'Days From Case Creation Until Relief' },
+            yaxis: { title: 'Frequency' }
+        };
+
+        var reliefData = [reliefUrgent, reliefHigh, reliefNormal, reliefLow];
+        Plotly.newPlot('reliefHistogram', reliefData, reliefLayout, { responsive: true });
+
+        var resolutionUrgent = {
+            x: {{ histogram_stats["Resolved"]["Urgent"] | safe }},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'Urgent'
+        };
+
+        var resolutionHigh = {
+            x: {{ histogram_stats["Resolved"]["High"] | safe}},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'High'
+        };
+
+        var resolutionNormal = {
+            x: {{ histogram_stats["Resolved"]["Normal"] | safe }},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'Normal'
+        };
+
+        var resolutionLow = {
+            x: {{ histogram_stats["Resolved"]["Low"] | safe}},
+            type: 'histogram',
+            opacity: 0.5,
+            name: 'Low'
+        };
+
+        var resolutionLayout = {
+            barmode: 'overlay',
+            title: 'Time to Resolution',
+            xaxis: { title: 'Days From Case Creation Until Resolution' },
+            yaxis: { title: 'Frequency' }
+        };
+
+        var resolutionData = [resolutionUrgent, resolutionHigh, resolutionNormal, resolutionLow];
+        Plotly.newPlot('resolutionHistogram', resolutionData, resolutionLayout, { responsive: true });
+
+        // Update table values
+        function median(values) {
+            if (values.length === 0) {
+                return 0;
+            }
+            // Sort the array in ascending order
+            const sortedNumbers = values.sort((a, b) => a - b);
+
+            // Calculate the median
+            let median;
+            const middleIndex = Math.floor(sortedNumbers.length / 2);
+
+            if (sortedNumbers.length % 2 === 0) {
+                // Even length array
+                median = (sortedNumbers[middleIndex - 1] + sortedNumbers[middleIndex]) / 2;
+            } else {
+                // Odd length array
+                median = sortedNumbers[middleIndex];
+            }
+
+            return median;
+        }
+
+        function average(values) {
+            if (values.length === 0) {
+                return 0;
+            }
+            let sum = 0;
+            for (let i = 0; i < values.length; i++) {
+                sum += values[i];
+            }
+            return sum / values.length;
+        }
+        function updateTable() {
+            document.getElementById("avg1").textContent = average({{ histogram_stats["Relief"]["Urgent"] | safe }}).toFixed(1);
+            document.getElementById("avg2").textContent = average({{ histogram_stats["Relief"]["High"] | safe }}).toFixed(1);
+            document.getElementById("avg3").textContent = average({{ histogram_stats["Relief"]["Normal"] | safe }}).toFixed(1);
+            document.getElementById("avg4").textContent = average({{ histogram_stats["Relief"]["Low"] | safe }}).toFixed(1);
+            document.getElementById("avg5").textContent = average({{ histogram_stats["Resolved"]["Urgent"] | safe }}).toFixed(1);
+            document.getElementById("avg6").textContent = average({{ histogram_stats["Resolved"]["High"] | safe }}).toFixed(1);
+            document.getElementById("avg7").textContent = average({{ histogram_stats["Resolved"]["Normal"] | safe }}).toFixed(1);
+            document.getElementById("avg8").textContent = average({{ histogram_stats["Resolved"]["Low"] | safe }}).toFixed(1);
+
+
+            document.getElementById("median1").textContent = median({{ histogram_stats["Relief"]["Urgent"] | safe }}).toFixed(1);
+            document.getElementById("median2").textContent = median({{ histogram_stats["Relief"]["High"] | safe }}).toFixed(1);
+            document.getElementById("median3").textContent = median({{ histogram_stats["Relief"]["Normal"] | safe }}).toFixed(1);
+            document.getElementById("median4").textContent = median({{ histogram_stats["Relief"]["Low"] | safe }}).toFixed(1);
+            document.getElementById("median5").textContent = median({{ histogram_stats["Resolved"]["Urgent"] | safe }}).toFixed(1);
+            document.getElementById("median6").textContent = median({{ histogram_stats["Resolved"]["High"] | safe }}).toFixed(1);
+            document.getElementById("median7").textContent = median({{ histogram_stats["Resolved"]["Normal"] | safe }}).toFixed(1);
+            document.getElementById("median8").textContent = median({{ histogram_stats["Resolved"]["Low"] | safe }}).toFixed(1);
+
+            document.getElementById("cases1").textContent = {{ histogram_stats["Relief"]["Urgent"] | safe }}.length;
+            document.getElementById("cases2").textContent = {{ histogram_stats["Relief"]["High"] | safe }}.length;
+            document.getElementById("cases3").textContent = {{ histogram_stats["Relief"]["Normal"] | safe }}.length;
+            document.getElementById("cases4").textContent = {{ histogram_stats["Relief"]["Low"] | safe }}.length;
+            document.getElementById("cases5").textContent = {{ histogram_stats["Resolved"]["Urgent"] | safe }}.length;
+            document.getElementById("cases6").textContent = {{ histogram_stats["Resolved"]["High"] | safe }}.length;
+            document.getElementById("cases7").textContent = {{ histogram_stats["Resolved"]["Normal"] | safe }}.length;
+            document.getElementById("cases8").textContent = {{ histogram_stats["Resolved"]["Low"] | safe }}.length;
+
+        }
+
+    // Initial table update
+    updateTable();
+</script>
 <script type="text/javascript" charset="utf8" src="{{ url_for('static', filename='js/stats.js') }}"></script>
 {% endblock %}

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -17,7 +17,8 @@ from t5gweb.libtelco5g import(
     redis_get,
     redis_set,
     generate_stats,
-    plot_stats
+    plot_stats,
+    generate_histogram_stats
 )
 from t5gweb.utils import (
     set_cfg
@@ -287,7 +288,8 @@ def get_stats():
     load_data()
     stats = generate_stats()
     x_values, y_values = plot_stats()
-    return render_template('ui/stats.html', now=load_data.now, stats=stats, x_values=x_values, y_values=y_values, page_title='stats')
+    histogram_stats = generate_histogram_stats()
+    return render_template('ui/stats.html', now=load_data.now, stats=stats, x_values=x_values, y_values=y_values, histogram_stats=histogram_stats,page_title='stats')
     
 @BP.route('/account/<string:account>')
 # @login_required
@@ -307,5 +309,7 @@ def get_account(account):
             list(stats["by_status"].values()),
         ),
     }
-    return render_template('ui/account.html', page_title=account, account=account, now=load_data.now, stats=stats, new_comments=comments, jira_server=load_data.jira_server, pie_stats=pie_stats)
+
+    histogram_stats = generate_histogram_stats(account)
+    return render_template('ui/account.html', page_title=account, account=account, now=load_data.now, stats=stats, new_comments=comments, jira_server=load_data.jira_server, pie_stats=pie_stats, histogram_stats=histogram_stats)
 


### PR DESCRIPTION
- Add `relief_at`, `resolution_at`, and `notified_users` to cache
- Add function to generate stats for relief and resolution charts
- Add charts to stats and account pages
- Include plotly.js via npm
- Update `package-lock.json` to match new npm v9 format
- Javascript code will be broken out into separate file and reformatted in separate WIP PR that will add automated linting tools
![Screenshot from 2023-07-03 11-40-14](https://github.com/RHsyseng/t5g-field-support-team-utils/assets/56094214/7830679f-2522-43cb-8e6e-9c46b4e0aed5)
