### PR TITLE
Fix dropdown Error

### DIFF
--- a/dashboard/src/t5gweb/templates/ui/account.html
+++ b/dashboard/src/t5gweb/templates/ui/account.html
@@ -284,7 +284,9 @@
                             {% elif new_comments[account][status][card]['severity'] == 'Urgent' %}
                                 {% set severity_order = 4 %}
                             {% endif %}
-                            <tr data-child-data="{{ new_comments[account][status][card] | tojson }}">
+                            <!-- data-child-data must be wrapped in SINGLE quotes.
+                                 Otherwise, our JS can't parse the data. -->
+                            <tr data-child-data='{{ new_comments[account][status][card] | tojson }}'>
                                 <td class="align-middle dt-control"></td>
                                 <td class="align-middle text-center">
                                     <a href="https://access.redhat.com/support/cases/#/case/{{ new_comments[account][status][card]['case_number'] }}"

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -47,7 +47,9 @@
                                 {% elif new_comments[account][status][card]['severity'] == 'Urgent' %}
                                     {% set severity_order = 4 %}
                                 {% endif %}
-                                <tr data-child-data="{{ new_comments[account][status][card] | tojson }}">
+                                <!-- data-child-data must be wrapped in SINGLE quotes.
+                                    Otherwise, our JS can't parse the data. -->
+                                <tr data-child-data='{{ new_comments[account][status][card] | tojson }}'>
                                     <td class="align-middle dt-control"></td>
                                     <td class="align-middle text-center">
                                         <a href="https://access.redhat.com/support/cases/#/case/{{ new_comments[account][status][card]['case_number'] }}"

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -48,7 +48,7 @@
                                     {% set severity_order = 4 %}
                                 {% endif %}
                                 <!-- data-child-data must be wrapped in SINGLE quotes.
-                                    Otherwise, our JS can't parse the data. -->
+                                     Otherwise, our JS can't parse the data. -->
                                 <tr data-child-data='{{ new_comments[account][status][card] | tojson }}'>
                                     <td class="align-middle dt-control"></td>
                                     <td class="align-middle text-center">


### PR DESCRIPTION
Revert to single quotes to fix error.

Explanation: 
Using double quotes causes an error because JSON also uses double quotes. So double quotes -> `"{"attribute":"value"}"`, which is interpreted as `"{"`, `":"` and so on. Using single quotes will result in a proper JSON object: `'{"attribute":"value"}'`