### PR TITLE
set-werkzeug-version

### DIFF
--- a/dashboard/src/setup.py
+++ b/dashboard/src/setup.py
@@ -19,5 +19,6 @@ setup(
         "python3-saml==1.15.0",
         "flask-login==0.6.2",
         "prometheus-flask-exporter==0.22.4",
+        "Werkzeug==2.3.7",
     ],
 )


### PR DESCRIPTION
See https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls

The latest container build pulled in a v3 version of the werkzeug module since flask doesn't specify its requirements. Seems to be broken. Setting our deps to include a known good working version