### PR TITLE
Remove python3.sh

### DIFF
--- a/dashboard/build/python3.sh
+++ b/dashboard/build/python3.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-container=$(buildah from registry.redhat.io/ubi8/ubi-minimal)
-echo "building container with id $container"
-buildah config --label maintainer="David Critch <dcritch@gmail.com>" "$container"
-buildah run "$container" microdnf -y install python3-pip gcc redhat-rpm-config python3-devel
-buildah commit --format docker "$container" python3:latest


### PR DESCRIPTION
`dashboard.sh` no longer builds using `python3.sh` as a dependency, so this PR removes that file