### PR TITLE
Add daily telco list + explanatory comments

### DIFF
--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -218,7 +218,10 @@ def get_cards(cfg, self=None, background=False):
             potential_escalation = True
         else:
             potential_escalation = False
-
+        if "Daily_Telco_OCP" in issue.fields.labels:
+            daily_telco = True
+        else:
+            daily_telco = False
         if watchlist and case_number in watchlist:
             watched = True
         else:
@@ -277,6 +280,7 @@ def get_cards(cfg, self=None, background=False):
             "notified_users": notified_users,
             "relief_at": relief_at,
             "resolved_at": resolved_at,
+            "daily_telco": daily_telco,
         }
 
     end = time.time()

--- a/dashboard/src/t5gweb/static/js/plugins.js
+++ b/dashboard/src/t5gweb/static/js/plugins.js
@@ -1,3 +1,6 @@
+// This file contains plugin code from the datatables plugin and should 
+// not be modified: https://datatables.net/plug-ins/sorting/natural#Browser
+
 // Deeplink
 /*!
    Copyright 2017 SpryMedia Ltd.

--- a/dashboard/src/t5gweb/static/js/table.js
+++ b/dashboard/src/t5gweb/static/js/table.js
@@ -83,6 +83,9 @@ function format(data) {
 
 // Initialize DataTable
 $(document).ready(function () {
+  // Define configuration options for DataTable:
+
+  // Deeplinking: https://datatables.net/blog/2017-07-24#Usage
   let deeplinkList = [
     "search.search",
     "order",
@@ -90,6 +93,8 @@ $(document).ready(function () {
     "searchPanes.preSelect",
   ];
   let searchOptions = $.fn.dataTable.ext.deepLink(deeplinkList);
+
+  // General Options for DataTable
   let options = {
     pageLength: 50,
     scrollX: true,
@@ -105,6 +110,8 @@ $(document).ready(function () {
       [10, 25, 50, -1],
       [10, 25, 50, "All"],
     ],
+
+    // searchPanes: https://datatables.net/extensions/searchpanes/
     searchPanes: {
       order: [
         "Severity",
@@ -116,6 +123,8 @@ $(document).ready(function () {
       ],
       columns: [2, 3, 7, 8, 10],
       initCollapsed: true,
+
+      // Define Custom Search Pane
       panes: [
         {
           name: "Escalated?",
@@ -131,10 +140,18 @@ $(document).ready(function () {
                 );
               },
             },
+            {
+              label: "Cases on Daily Telco List",
+              value: function (rowData, rowIdx) {
+                return rowData[16] === "True";
+              },
+            },
           ],
         },
       ],
     },
+
+    // When table is loaded, remove "Loading Table..." message and display table
     initComplete: function (settings, json) {
       $("div.loading").remove();
       $(".case-table").show();
@@ -178,8 +195,15 @@ $(document).ready(function () {
         },
         targets: [3],
       },
+      // Hide Daily Telco List Column
+      {
+        targets: [16],
+        visible: false,
+      },
     ],
   };
+
+  // Initialize Table w/ options defined above
   let table = $("#data").DataTable($.extend(true, options, searchOptions));
   table.searchPanes.container().prependTo(table.table().container());
   table.searchPanes.resizePanes();
@@ -254,7 +278,7 @@ $(document).ready(function () {
         // Update search section of query in place
         query = query.replace(
           /search.search=.[^&]*/i,
-          "search.search=" + search,
+          "search.search=" + search
         );
       } else {
         if (query.length > 1) {
@@ -303,7 +327,7 @@ $(document).ready(function () {
           // Update search panes section of query in place
           query = query.replace(
             /searchPanes.preSelect=.[^&]*/i,
-            "searchPanes.preSelect=" + JSON.stringify(panes),
+            "searchPanes.preSelect=" + JSON.stringify(panes)
           );
         } else {
           if (query.length > 1) {

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -27,6 +27,7 @@
                         <th rowspan="2" class="text-center">Most Recent Comment</th>
                         <th rowspan="2" class="text-center">Days Open</th>
                         <th rowspan="2" class="text-center">Case Last Updated</th>
+                        <th rowspan="2" class="text-center">Daily Telco List</th>
                     </tr>
                     <tr>
                         <th class="text-center">On Prio-list?</th>
@@ -107,6 +108,7 @@
                                     </td>
                                     <td class="align-middle text-center">{{ new_comments[account][status][card]['case_days_open'] }}</td>
                                     <td class="align-middle text-center">{{ new_comments[account][status][card]['case_updated_date'] }}</td>
+                                    <td class="align-middle text-center">{{ new_comments[account][status][card]['daily_telco'] }}</td>
                                 </tr>
                             {% endfor %}
                         {% endfor %}


### PR DESCRIPTION
- Add daily telco list to cards. It is then added to the table as a hidden, non-visible column so that we can filter on it using the search panes without altering the existing table:

![image](https://github.com/RHsyseng/t5g-field-support-team-utils/assets/56094214/428d58b4-00eb-495e-8600-d3df2b0a07ee)
