### PR TITLE
Updating software versions

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,9 +1,12 @@
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 LABEL org.opencontainers.image.authors="Telco5G Field Engineering Team"
 RUN dnf -y install python3-pip gcc redhat-rpm-config python3-devel npm libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel; dnf clean all
 RUN dnf clean all
 COPY src/ /srv/
 WORKDIR /srv 
 RUN pip3 install --no-cache-dir .
-RUN npm ci --prefix t5gweb/static
+RUN npm ci --prefix t5gweb/static --ignore-scripts
+RUN groupadd dashboard
+RUN useradd -g dashboard dashboard
+USER dashboard
 EXPOSE 8080

--- a/dashboard/src/setup.py
+++ b/dashboard/src/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="t5gweb",
-    version="0.221121",
+    version="1.240110",
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
@@ -14,7 +14,7 @@ setup(
         "slack_sdk==3.19.4",
         "redis==4.3.4",
         "python_bugzilla==3.2.0",
-        "celery==5.2.7",
+        "celery==5.3.6",
         "flower==1.2.0",
         "python3-saml==1.15.0",
         "flask-login==0.6.2",


### PR DESCRIPTION
Bumping Fedora up to 39, along with celery to 5.3 due to [updated python](https://stackoverflow.com/questions/76272422/attributeerror-entrypoints-object-has-no-attribute-get)

Also adding a user via the Dockerfile to squelch a sonar finding