### PR TITLE
Add env_file to ui container

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,7 +1,6 @@
 FROM registry.fedoraproject.org/fedora:38
 LABEL org.opencontainers.image.authors="Telco5G Field Engineering Team"
 RUN dnf -y install python3-pip gcc redhat-rpm-config python3-devel npm libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel; dnf clean all
-RUN dnf clean all
 COPY src/ /srv/
 WORKDIR /srv 
 RUN pip3 install --no-cache-dir .

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     image: localhost/dashboard
     build: .
     command: gunicorn --bind 0.0.0.0:8080 --timeout 1200 wsgi:app --reload
+    env_file:
+      - ../cfg/sample.env
     ports:
       - 8080:8080
     environment:


### PR DESCRIPTION
Add the env_file to the UI container, for consistency and to make sure that the `READ_ONLY` variable is passed in. Also remove a redundant `dnf clean all` command in the Dockerfile