### PR TITLE
Remove quotation marks from sample.env

### DIFF
--- a/cfg/sample.env
+++ b/cfg/sample.env
@@ -6,6 +6,8 @@
 # However, if some information is omitted, it shouldn't affect other data gathering 
 # scripts. For example, if bz_key is omitted, other data should still be gathered.
 
+# NOTE: If you are using podman-compose, omit all quotation marks.
+# See https://github.com/containers/podman-compose/issues/721 for more details.
 
 # Don't change this, unless you want the scripts to make changes to the Jira Board that
 # you've defined below. Shouldn't need to change this for most development work.
@@ -14,26 +16,26 @@ READ_ONLY=true
 ### Red Hat API
 # Offline token https://access.redhat.com/management/api
 # How to use it https://access.redhat.com/articles/3626371
-offline_token='<YOUR_SECRET>'
-redhat_api='https://access.redhat.com/hydra/rest'
+offline_token=<YOUR_SECRET>
+redhat_api=https://access.redhat.com/hydra/rest
 watchlist_url=<WATCHLIST_URL>
 
 # search query 
-case_query='case_tags:*shift_telco5g*'
+case_query=case_tags:*shift_telco5g*
 
 ### Bugzilla API
 # Python Wrapper for BZ API: https://github.com/python-bugzilla/python-bugzilla
-bz_key="<BZ_KEY>"
+bz_key=<BZ_KEY>
 
 # Jira
-jira_sprint='T5GFE'
-jira_server='https://issues.redhat.com'
-jira_project='KNIECO'
-jira_component='KNI Labs & Field'
-jira_board='KNI-ECO Labs & Field'
-jira_query='field'
-jira_pass='<JIRA_PASS>'
+jira_sprint=T5GFE
+jira_server=https://issues.redhat.com
+jira_project=KNIECO
+jira_component=KNI Labs & Field
+jira_board=KNI-ECO Labs & Field
+jira_query=field
+jira_pass=<JIRA_PASS>
 
 # Jira escalations
-jira_escalations_project='RHOCPPRIO'
-jira_escalations_label='Telco5g'
+jira_escalations_project=RHOCPPRIO
+jira_escalations_label=Telco5g


### PR DESCRIPTION
`podman-compose` interprets quotes literally, so they shouldn't be included in the `.env` file.