### PR TITLE
Truncate long summaries

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -278,9 +278,7 @@ def create_cards(cfg, new_cases, action="none"):
             "components": [{"name": cfg["component"]}],
             "priority": {"name": priority},
             "labels": cfg["labels"],
-            "summary": summary[:253] + ".."
-            if len(summary) > 253
-            else summary,
+            "summary": summary[:253] + ".." if len(summary) > 253 else summary,
             "description": full_description[:253] + ".."
             if len(full_description) > 253
             else full_description,

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -271,13 +271,16 @@ def create_cards(cfg, new_cases, action="none"):
             + cases[case]["description"]
             + "\r\n"
         )
+        summary = case + ": " + cases[case]["problem"]
         card_info = {
             "project": {"key": cfg["project"]},
             "issuetype": {"name": cfg["type"]},
             "components": [{"name": cfg["component"]}],
             "priority": {"name": priority},
             "labels": cfg["labels"],
-            "summary": case + ": " + cases[case]["problem"],
+            "summary": summary[:253] + ".."
+            if len(summary) > 253
+            else summary,
             "description": full_description[:253] + ".."
             if len(full_description) > 253
             else full_description,


### PR DESCRIPTION
Similar to what we had to do on long descriptions, we were getting errors trying to create a card since the problem description was too long.