### PR TITLE
Automatically redirect to homepage if login is disabled

### DIFF
--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -1,4 +1,5 @@
 """UI views for t5gweb"""
+
 # The login code was derived from:
 # https://github.com/SAML-Toolkits/python3-saml/tree/master/demo-flask
 # License - https://github.com/SAML-Toolkits/python3-saml/blob/master/LICENSE
@@ -96,6 +97,9 @@ def load_data():
 @BP.route("/", methods=["GET", "POST"])
 def login():
     """Handles redirects back and forth from SAML Provider and user creation in Redis"""
+    login_disabled = os.getenv("FLASK_LOGIN_DISABLED", "false") == "true"
+    if login_disabled:
+        return redirect(url_for("ui.index"))
     req = prepare_flask_request(request)
     auth = init_saml_auth(req)
     errors = []

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -97,6 +97,7 @@ def load_data():
 @BP.route("/", methods=["GET", "POST"])
 def login():
     """Handles redirects back and forth from SAML Provider and user creation in Redis"""
+    # Anything except for 'true' will be set to False
     login_disabled = os.getenv("FLASK_LOGIN_DISABLED", "false") == "true"
     if login_disabled:
         return redirect(url_for("ui.index"))


### PR DESCRIPTION
Right now, if you spin up a test environment, you will be greeted by a 500 server error. This is because we have disabled SSO login for test environments, but are still sending the "user" to the login page. This PR will automatically redirect the user to the homepage if it detects that login is disabled.