### PR TITLE
Remove python version from black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ repos:
     rev: 23.11.0
     hooks:
       - id: black
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.12
 
   # isort
   - repo: https://github.com/pycqa/isort
@@ -39,7 +34,7 @@ repos:
 
   # prettier
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.1.0'
+    rev: v3.1.0
     hooks:
       - id: prettier
         types: [javascript]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
-# Some Common Ways to Contribute
 
-## Add a new page
+## Pre-Commit
+
+We have a `.pre-commit-config.yaml` file in our repository that will help you avoid common linting/formatting mistakes when you commit your changes. You can get set up by following
+pre-commit's [quick start guide](https://pre-commit.com/#quick-start).
+
+## Some Common Ways to Contribute
+
+### Add a new page
 
 The official Flask documentation contains a useful [walkthrough](https://flask.palletsprojects.com/en/3.0.x/quickstart/#rendering-templates) of how to add/modify a new web view.
 
@@ -48,7 +54,7 @@ You will be able to see your page by running your Flask server and visiting `<UR
 Our templates are contained within `dashboard/src/t5gweb/templates` and our endpoints are
 defined in `dashboard/src/t5gweb/ui.py`.
 
-## Alter JavaScript
+### Alter JavaScript
 
 We are using a framework called [DataTables](https://datatables.net/) to add interactive tables to our dashboard. The majority of our JavaScript is related to these tables:
 
@@ -98,7 +104,7 @@ And that's it, we can now filter our table by "Case Status":
 
 The DataTables [documentation](https://datatables.net) is very extensive, and can help you find and make any other changes that you might think of.
 
-## Adding tests
+### Adding tests
 
 We use [pytest](https://docs.pytest.org/en/8.0.x/) for our unit tests. Pytest's docs are very helpful, but here's a simple example to get started:
 
@@ -178,7 +184,7 @@ In this case, the API call will not take place, and will instead be represented 
 
 Our unit tests are located in `tests/`, and we run tests automatically for PR's and commits on the `main` branch via GitHub Actions (`.github/workflows/linter.yml`). You can run tests locally by installing pytest and pytest-mock, and then running `pytest` from the root directory of the repository (`t5g-field-support-team-utils/`).
 
-## Add a new scheduled task
+### Add a new scheduled task
 
 We use [Celery beat](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html) to run our scheduled tasks, which gather data from various APIs and combine it into what is visible on our dashboard.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+# Contribution Guide
 
 ## Pre-Commit
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Another volume is created for `/srv/t5gweb/static/node_modules/`. Without this v
 
 If you want to add a new JS package, you'll need to add it to `package.json` and `package-lock.json` , which are located in `dashboard/src/t5gweb/static/`. Then you need to remove the relevant volume (`podman volume rm dashboard_dashboard-ui_<HASH>`) and rebuild the image.
 
+
+Please see our [CONTRIBUTING.md](https://github.com/RHsyseng/t5g-field-support-team-utils/blob/main/CONTRIBUTING.md) for further development help.
 ## CI
 
 This project has a CI that is triggered on every push.


### PR DESCRIPTION
This is causing some issues if people aren't running python 3.12 on their local machine, so I think that it's better to remove that option altogether.