### PR TITLE
Make sure linked text is accounted for

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,3 +204,18 @@ def setup_scheduled_tasks(sender, **kwargs):
 ```
 
 Now, the message will be printed every 15 minutes.
+
+### Common Debugging Techniques
+
+To see how the DataTables framework parses your data, you can use the following snippet (adapted from DataTables [docs](https://datatables.net/reference/api/row().data()#Examples)):
+
+```{javascript}
+$(document).ready(function () {
+...
+  $('#data tbody').on('click', 'tr', function () {
+    console.log(table.row(this).data());
+  });
+...
+```
+
+This can be useful when setting up and modifying your table's configuration, especially with regards to searching and ordering.

--- a/dashboard/src/t5gweb/static/js/table.js
+++ b/dashboard/src/t5gweb/static/js/table.js
@@ -142,7 +142,7 @@ $(document).ready(function () {
               label: "Cases on Prio-list or Watchlist or Crit Sit",
               value: function (rowData, rowIdx) {
                 return (
-                  rowData[3] === "Yes" ||
+                  rowData[3].includes("Yes") ||
                   rowData[4] === "Yes" ||
                   rowData[5] === "Yes"
                 );


### PR DESCRIPTION
Entries with "Yes" in the "on prio-list" weren't showing up when selecting "Cases on Prio-list or Watchlist or Crit Sit" from the "Escalated?" drop-down menu. This was because some of the entries were hyperlinked (`<a href="example.com">Yes</a>`) - our code was only checking if the `row == "Yes"`, so I've changed it to look for code that includes "Yes". Now it will match rows where the entry is "Yes", as well as rows where the entry is `"<a href='example.com'>Yes</a>"`.

I've also started a running list in CONTRIBUTING.md with some tips to help debug issues.