### PR TITLE
Remove redundant call to retrieve issue comments

### DIFF
--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -134,7 +134,7 @@ def get_cards(cfg, self=None, background=False):
                 },
             )
         issue = jira_conn.issue(card)
-        comments = jira_conn.comments(issue)
+        comments = issue.fields.comment.comments
         card_comments = []
         for comment in comments:
             body = comment.body


### PR DESCRIPTION
We were making a separate call for comments, however the latest JIRA API docs show that we already have them when we pull a card. Removing the redundant separate call to retrieve them.