### PR TITLE
Adding coloured days when broken SLA

### DIFF
--- a/dashboard/src/t5gweb/templates/macros/macros.html
+++ b/dashboard/src/t5gweb/templates/macros/macros.html
@@ -49,7 +49,7 @@
     {% endfor %}
 {%- endmacro %}
 
-{% macro cases_table(new_comments, jira_server) -%}
+{% macro cases_table(new_comments, jira_server, sla_settings) -%}
 <div class="container-fluid pt-2" id="expand-buttons">
     <button type="button" class="btn btn-outline-dark" id="expand-button">Expand All Rows</button>
     <button type="button" class="btn btn-outline-dark" id="collapse-button">Collapse All Rows</button>
@@ -154,7 +154,23 @@
                             <td class="align-middle">
                                 <span class="fw-bold fst-italic">{{ new_comments[account][status][card]['comments'][-1][1][:10] }}</span> - {{ new_comments[account][status][card]['comments'][-1][0] | safe }}
                             </td>
-                            <td class="align-middle text-center">{{ new_comments[account][status][card]['case_days_open'] }}</td>
+                            <td class="align-middle text-center">
+                                {% set severity_text = new_comments[account][status][card]['severity'] %}
+                                {% set days_color = ' ' %}
+                                {% if new_comments[account][status][card]['case_status'] != "Closed" %}
+                                    {% if new_comments[account][status][card]['account'] in sla_settings["partners"] %}
+                                        {% if new_comments[account][status][card]['case_days_open'] > sla_settings["days"][severity_text]/2 %}
+                                            {% set days_color = 'badge severity high' %}
+                                            {% if new_comments[account][status][card]['case_days_open'] >= sla_settings["days"][severity_text] %}
+                                                {% set days_color = 'badge severity urgent' %}
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                                <span class="{{ days_color }}">
+                                    {{ new_comments[account][status][card]['case_days_open'] }}
+                                </span>
+                            </td>
                             <td class="align-middle text-center">{{ new_comments[account][status][card]['case_updated_date'] }}</td>
                             <td class="align-middle text-center">{{ new_comments[account][status][card]['daily_telco'] }}</td>
                         </tr>
@@ -165,3 +181,4 @@
     </table>
 </div>
 {%- endmacro %}
+

--- a/dashboard/src/t5gweb/templates/ui/account.html
+++ b/dashboard/src/t5gweb/templates/ui/account.html
@@ -245,7 +245,7 @@
     {% endif %}
     <br>
     <h2>Cases:</h2>
-    {{ macros.cases_table(new_comments, jira_server) }}
+    {{ macros.cases_table(new_comments, jira_server, sla_settings) }}
     <script>
     // Create the histograms
     var reliefUrgent = {

--- a/dashboard/src/t5gweb/templates/ui/table.html
+++ b/dashboard/src/t5gweb/templates/ui/table.html
@@ -3,7 +3,7 @@
 {% block title %}{{ page_title }}{% endblock %}
 {% block content %}
     <div class="container-fluid copy mt-5">
-        {{ macros.cases_table(new_comments, jira_server) }}
+        {{ macros.cases_table(new_comments, jira_server, sla_settings) }}
     </div>
     <!-- Include jQuery + DataTables -->
     <script type="text/javascript"

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -301,6 +301,7 @@ def trends():
         new_comments=get_trending_cards(cards),
         jira_server=cfg["server"],
         page_title="trends",
+        sla_settings=cfg["sla_settings"],
     )
 
 
@@ -316,6 +317,7 @@ def table_view():
         new_comments=get_new_comments(cards),
         jira_server=cfg["server"],
         page_title="severity",
+        sla_settings=cfg["sla_settings"],
     )
 
 
@@ -331,6 +333,7 @@ def table_view_all():
         new_comments=get_new_comments(cards=cards, new_comments_only=False),
         jira_server=cfg["server"],
         page_title="all-severity",
+        sla_settings=cfg["sla_settings"],
     )
 
 
@@ -348,6 +351,7 @@ def weekly_updates():
         new_comments=get_new_comments(cards),
         jira_server=cfg["server"],
         page_title="weekly-update",
+        sla_settings=cfg["sla_settings"],
     )
 
 
@@ -389,6 +393,7 @@ def get_account(account):
         jira_server=cfg["server"],
         pie_stats=pie_stats,
         histogram_stats=histogram_stats,
+        sla_settings=cfg["sla_settings"],
     )
 
 
@@ -413,4 +418,5 @@ def get_engineer(engineer):
         pie_stats=pie_stats,
         histogram_stats=histogram_stats,
         engineer_view=True,
+        sla_settings=cfg["sla_settings"],
     )

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -238,7 +238,10 @@ def set_defaults():
     defaults["slack_channel"] = ""
     defaults["max_jira_results"] = 1000
     defaults["max_portal_results"] = 5000
-    defaults["sla_settings"] = {"days": {"Urgent": 14,"High": 20,"Normal": 90,"Low": 180},"partners": []}
+    defaults["sla_settings"] = {
+        "days": {"Urgent": 14, "High": 20, "Normal": 90, "Low": 180},
+        "partners": [],
+    }
     return defaults
 
 

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -238,7 +238,7 @@ def set_defaults():
     defaults["slack_channel"] = ""
     defaults["max_jira_results"] = 1000
     defaults["max_portal_results"] = 5000
-    defaults["sla_settings"] = ""
+    defaults["sla_settings"] = {"days": {"Urgent": 14,"High": 20,"Normal": 90,"Low": 180},"partners": []}
     return defaults
 
 

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -186,11 +186,8 @@ def set_cfg():
         if os.environ.get("jira_labels")
         else []
     )
-    cfg["sla_settings"] = (
-        json.loads(os.environ.get("sla_settings"))
-        if os.environ.get("sla_settings")
-        else None
-    )
+    if os.environ.get("sla_settings"):
+        cfg["sla_settings"] = json.loads(os.environ.get("sla_settings"))
     # sso
     cfg["rbac"] = os.environ.get("rbac").split(",") if os.environ.get("rbac") else []
     return cfg

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -186,7 +186,11 @@ def set_cfg():
         if os.environ.get("jira_labels")
         else []
     )
-
+    cfg["sla_settings"] = (
+        json.loads(os.environ.get("sla_settings"))
+        if os.environ.get("sla_settings")
+        else None
+    )
     # sso
     cfg["rbac"] = os.environ.get("rbac").split(",") if os.environ.get("rbac") else []
     return cfg
@@ -234,6 +238,7 @@ def set_defaults():
     defaults["slack_channel"] = ""
     defaults["max_jira_results"] = 1000
     defaults["max_portal_results"] = 5000
+    defaults["sla_settings"] = ""
     return defaults
 
 


### PR DESCRIPTION
Adding the needed logic to highlight the numbers in the "open days" column when the SLA for that partner has been broken (marked as red) or is higher than half of the defined days (marked as orange). Different colors are applied in each case.

A new parameter needs to be added int he env conf, an example:
```
sla_config={
  "days": {
    "Urgent": 14,
    "High": 20,
    "Normal": 90,
    "Low": 180
  },
  "partners": [
    "...",
  ]
}
```
