### PR TITLE
fixing sonar and linting issues, part 1

### DIFF
--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -9,8 +9,8 @@ from t5gweb.cache import (
     get_cases,
     get_escalations,
     get_issue_details,
-    get_watchlist,
     get_stats,
+    get_watchlist,
 )
 from t5gweb.libtelco5g import generate_stats, redis_get
 from t5gweb.utils import set_cfg

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -1,4 +1,5 @@
 """API endpoints for t5gweb"""
+
 from flask import Blueprint, jsonify, request
 from flask_login import login_required
 from t5gweb.cache import (
@@ -9,6 +10,7 @@ from t5gweb.cache import (
     get_escalations,
     get_issue_details,
     get_watchlist,
+    get_stats,
 )
 from t5gweb.libtelco5g import generate_stats, redis_get
 from t5gweb.utils import set_cfg
@@ -29,6 +31,7 @@ def index():
             "{}refresh/escalations".format(request.base_url),
             "{}refresh/watchlist".format(request.base_url),
             "{}refresh/issues".format(request.base_url),
+            "{}refresh/stats".format(request.base_url),
             "{}cards".format(request.base_url),
             "{}cases".format(request.base_url),
             "{}bugs".format(request.base_url),
@@ -66,6 +69,9 @@ def refresh(data_type):
     elif data_type == "issues":
         get_issue_details(cfg)
         return jsonify({"caching issues": "ok"})
+    elif data_type == "stats":
+        get_stats()
+        return jsonify({"caching stats": "ok"})
     else:
         return jsonify({"error": "unknown data type: {}".format(data_type)})
 

--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -12,7 +12,7 @@ import requests
 
 from jira.exceptions import JIRAError
 from t5gweb import libtelco5g
-from t5gweb.utils import make_headers, format_date
+from t5gweb.utils import format_date, make_headers
 
 
 def get_cases(cfg):
@@ -79,7 +79,10 @@ def get_escalations(cfg):
     max_cards = cfg["max_jira_results"]
     project = libtelco5g.get_project_id(jira_conn, cfg["jira_escalations_project"])
     escalations_label = cfg["jira_escalations_label"]
-    jira_query = f'project = {project.id} AND labels = "{escalations_label}" AND status != "Closed"'
+    jira_query = (
+        f'project = {project.id} AND labels = '
+        f'"{escalations_label}" AND status != "Closed"'
+    )
 
     escalated_cards = jira_conn.search_issues(jira_query, 0, max_cards).iterable
     escalations = []

--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -9,7 +9,6 @@ import xmlrpc
 
 import bugzilla
 import requests
-
 from jira.exceptions import JIRAError
 from t5gweb import libtelco5g
 from t5gweb.utils import format_date, make_headers
@@ -80,7 +79,7 @@ def get_escalations(cfg):
     project = libtelco5g.get_project_id(jira_conn, cfg["jira_escalations_project"])
     escalations_label = cfg["jira_escalations_label"]
     jira_query = (
-        f'project = {project.id} AND labels = '
+        f"project = {project.id} AND labels = "
         f'"{escalations_label}" AND status != "Closed"'
     )
 

--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -1,4 +1,5 @@
 """cache.py: caching functions for the t5gweb"""
+
 import datetime
 import json
 import logging
@@ -8,8 +9,10 @@ import xmlrpc
 
 import bugzilla
 import requests
-import t5gweb.libtelco5g as libtelco5g
+
 from jira.exceptions import JIRAError
+from t5gweb import libtelco5g
+from t5gweb.utils import make_headers, format_date
 
 
 def get_cases(cfg):
@@ -18,10 +21,10 @@ def get_cases(cfg):
     token = libtelco5g.get_token(cfg["offline_token"])
     query = cfg["query"]
     fields = ",".join(cfg["fields"])
-    query = "({})".format(query)
+    query = f"({query})"
     num_cases = cfg["max_portal_results"]
     payload = {"q": query, "partnerSearch": "false", "rows": num_cases, "fl": fields}
-    headers = {"Accept": "application/json", "Authorization": "Bearer " + token}
+    headers = make_headers(token)
     url = f"{cfg['redhat_api']}/search/cases"
 
     logging.warning("searching the portal for cases")
@@ -29,9 +32,7 @@ def get_cases(cfg):
     r = requests.get(url, headers=headers, params=payload)
     cases_json = r.json()["response"]["docs"]
     end = time.time()
-    logging.warning(
-        "found {} cases in {} seconds".format(len(cases_json), (end - start))
-    )
+    logging.warning("found %s cases in %s seconds", len(cases_json), end - start)
     cases = {}
     for case in cases_json:
         cases[case["case_number"]] = {
@@ -77,9 +78,8 @@ def get_escalations(cfg):
     jira_conn = libtelco5g.jira_connection(cfg)
     max_cards = cfg["max_jira_results"]
     project = libtelco5g.get_project_id(jira_conn, cfg["jira_escalations_project"])
-    jira_query = 'project = {} AND labels = "{}" AND status != "Closed"'.format(
-        project.id, cfg["jira_escalations_label"]
-    )
+    escalations_label = cfg["jira_escalations_label"]
+    jira_query = f'project = {project.id} AND labels = "{escalations_label}" AND status != "Closed"'
 
     escalated_cards = jira_conn.search_issues(jira_query, 0, max_cards).iterable
     escalations = []
@@ -103,15 +103,15 @@ def get_cards(cfg, self=None, background=False):
     max_cards = cfg["max_jira_results"]
     start = time.time()
     project = libtelco5g.get_project_id(jira_conn, cfg["project"])
-    logging.warning("project: {}".format(project))
+    logging.warning("project: %s", project)
     board = libtelco5g.get_board_id(jira_conn, cfg["board"])
-    logging.warning("board: {}".format(board))
+    logging.warning("board: %s", board)
     if cfg["sprintname"] and cfg["sprintname"] != "":
         sprint = libtelco5g.get_latest_sprint(jira_conn, board.id, cfg["sprintname"])
         jira_query = (
             "sprint=" + str(sprint.id) + ' AND labels = "' + cfg["jira_query"] + '"'
         )
-        logging.warning("sprint: {}".format(sprint))
+        logging.warning("sprint: %s", sprint)
     else:
         jira_query = (
             "project=" + str(project.id) + ' AND labels = "' + cfg["jira_query"] + '"'
@@ -159,9 +159,7 @@ def get_cards(cfg, self=None, background=False):
             card_comments.append((body, tstamp))
         case_number = libtelco5g.get_case_from_link(jira_conn, card)
         if not case_number or case_number not in cases.keys():
-            logging.warning(
-                "card isn't associated with a case. discarding ({})".format(card)
-            )
+            logging.warning("card isn't associated with a case. discarding (%s)", card)
             continue
         assignee = {"displayName": None, "key": None, "name": None}
         if issue.fields.assignee:
@@ -265,16 +263,12 @@ def get_cards(cfg, self=None, background=False):
             "crit_sit": crit_sit,
             "group_name": group_name,
             "case_updated_date": datetime.datetime.strftime(
-                datetime.datetime.strptime(
-                    cases[case_number]["last_update"], "%Y-%m-%dT%H:%M:%SZ"
-                ),
+                format_date(cases[case_number]["last_update"]),
                 "%Y-%m-%d %H:%M",
             ),
             "case_days_open": (
                 time_now.replace(tzinfo=None)
-                - datetime.datetime.strptime(
-                    cases[case_number]["createdate"], "%Y-%m-%dT%H:%M:%SZ"
-                )
+                - format_date(cases[case_number]["createdate"])
             ).days,
             "case_created": cases[case_number]["createdate"],
             "notified_users": notified_users,
@@ -284,9 +278,11 @@ def get_cards(cfg, self=None, background=False):
         }
 
     end = time.time()
-    logging.warning("got {} cards in {} seconds".format(len(jira_cards), (end - start)))
+    logging.warning("got %s cards in %s seconds", len(jira_cards), (end - start))
     libtelco5g.redis_set("cards", json.dumps(jira_cards))
-    libtelco5g.redis_set("timestamp", json.dumps(str(datetime.datetime.utcnow())))
+    libtelco5g.redis_set(
+        "timestamp", json.dumps(str(datetime.datetime.now(datetime.timezone.utc)))
+    )
 
 
 def get_watchlist(cfg):
@@ -298,7 +294,7 @@ def get_watchlist(cfg):
     token = libtelco5g.get_token(cfg["offline_token"])
     num_cases = cfg["max_portal_results"]
     payload = {"rows": num_cases}
-    headers = {"Accept": "application/json", "Authorization": "Bearer " + token}
+    headers = make_headers(token)
     url = f"{cfg['redhat_api']}/eh/escalations?highlight=true"
 
     r = requests.get(url, headers=headers, params=payload)
@@ -307,9 +303,9 @@ def get_watchlist(cfg):
     for watched in r.json():
         watched_cases = watched["cases"]
         for case in watched_cases:
-            caseNumber = case["caseNumber"]
-            if caseNumber in cases:
-                watchlist.append(caseNumber)
+            case_number = case["caseNumber"]
+            if case_number in cases:
+                watchlist.append(case_number)
 
     libtelco5g.redis_set("watchlist", json.dumps(watchlist))
 
@@ -324,7 +320,7 @@ def get_case_details(cfg):
 
     bz_dict = {}
     token = libtelco5g.get_token(cfg["offline_token"])
-    headers = {"Accept": "application/json", "Authorization": "Bearer " + token}
+    headers = make_headers(token)
     case_details = {}
     logging.warning("getting all bugzillas and case details")
     for case in cases:
@@ -333,10 +329,7 @@ def get_case_details(cfg):
             r_case = requests.get(case_endpoint, headers=headers)
             if r_case.status_code == 401:
                 token = libtelco5g.get_token(cfg["offline_token"])
-                headers = {
-                    "Accept": "application/json",
-                    "Authorization": "Bearer " + token,
-                }
+                headers = make_headers(token)
                 r_case = requests.get(case_endpoint, headers=headers)
 
             crit_sit = r_case.json().get("critSit", False)
@@ -375,9 +368,7 @@ def get_bz_details(cfg):
                 bugs = bz_api.getbug(bug["bugzillaNumber"])
             except xmlrpc.client.Fault:
                 logging.warning(
-                    "error retrieving bug {} - restricted?".format(
-                        bug["bugzillaNumber"]
-                    )
+                    "error retrieving bug %s - restricted?", bug["bugzillaNumber"]
                 )
                 bugs = None
             if bugs:
@@ -411,7 +402,7 @@ def get_issue_details(cfg):
         return
 
     token = libtelco5g.get_token(cfg["offline_token"])
-    headers = {"Accept": "application/json", "Authorization": "Bearer " + token}
+    headers = make_headers(token)
 
     logging.warning("attempting to connect to jira...")
     jira_conn = libtelco5g.jira_connection(cfg)
@@ -428,7 +419,7 @@ def get_issue_details(cfg):
                     try:
                         bug = jira_conn.issue(issue["resourceKey"])
                     except JIRAError:
-                        logging.warning("Can't access {}".format(issue["resourceKey"]))
+                        logging.warning("Can't access %s", issue["resourceKey"])
                         continue
 
                     # Retrieve QA contact from Jira bug
@@ -486,9 +477,7 @@ def get_issue_details(cfg):
                             "title": issue["title"],
                             "status": issue["status"],
                             "updated": datetime.datetime.strftime(
-                                datetime.datetime.strptime(
-                                    str(issue["lastModifiedDate"]), "%Y-%m-%dT%H:%M:%SZ"
-                                ),
+                                format_date(str(issue["lastModifiedDate"])),
                                 "%Y-%m-%d",
                             ),
                             "qa_contact": qa_contact,
@@ -511,7 +500,7 @@ def get_stats():
     logging.warning("caching {} stats")
     all_stats = libtelco5g.redis_get("stats")
     new_stats = libtelco5g.generate_stats()
-    tstamp = datetime.datetime.utcnow()
+    tstamp = datetime.datetime.now(datetime.timezone.utc)
     today = tstamp.strftime("%Y-%m-%d")
     stats = {today: new_stats}
     all_stats.update(stats)

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -23,10 +23,10 @@ import requests
 from jira import JIRA
 from t5gweb.utils import (
     exists_or_zero,
+    format_date,
     get_random_member,
     get_token,
     make_headers,
-    format_date,
 )
 
 # for portal to jira mapping

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -9,7 +9,7 @@ from datetime import date, datetime, timezone
 
 import click
 from flask.cli import with_appcontext
-from t5gweb.utils import get_fake_data, set_cfg, format_date
+from t5gweb.utils import format_date, get_fake_data, set_cfg
 
 from . import cache, libtelco5g
 

--- a/dashboard/src/t5gweb/t5gweb.py
+++ b/dashboard/src/t5gweb/t5gweb.py
@@ -9,7 +9,7 @@ from datetime import date, datetime, timezone
 
 import click
 from flask.cli import with_appcontext
-from t5gweb.utils import get_fake_data, set_cfg
+from t5gweb.utils import get_fake_data, set_cfg, format_date
 
 from . import cache, libtelco5g
 
@@ -25,14 +25,11 @@ def get_new_cases():
     new_cases = {
         c: d
         for (c, d) in sorted(cases.items(), key=lambda i: i[1]["severity"])
-        if (
-            today - datetime.strptime(d["createdate"], "%Y-%m-%dT%H:%M:%SZ").date()
-        ).days
-        <= interval
+        if (today - format_date(d["createdate"]).date()).days <= interval
     }
     for case in new_cases:
         new_cases[case]["severity"] = re.sub(
-            r"\(|\)| |[0-9]", "", new_cases[case]["severity"]
+            r"\(|\)| |\d", "", new_cases[case]["severity"]
         )
     return new_cases
 

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -159,12 +159,12 @@ def login():
 
         user = User(attributes["rhatUUID"][0])
         login_user(user)
-        next = request.args.get("next")
+        next_page = request.args.get("next")
 
         # Avoid 'Open Redirect'
-        if not is_safe_url(next):
+        if not is_safe_url(next_page):
             return abort(400)
-        return redirect(next or url_for("ui.index"))
+        return redirect(next_page or url_for("ui.index"))
 
     return render_template(
         "ui/login.html",

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -4,9 +4,9 @@
 # https://github.com/SAML-Toolkits/python3-saml/tree/master/demo-flask
 # License - https://github.com/SAML-Toolkits/python3-saml/blob/master/LICENSE
 import json
+import logging
 import os
 from urllib.parse import urljoin, urlparse
-import logging
 
 from flask import (
     Blueprint,

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -1,12 +1,12 @@
 """utils.py: utility functions for the t5gweb"""
 
+import datetime
 import json
 import logging
 import os
 import random
 import re
 import smtplib
-import datetime
 from email.message import EmailMessage
 
 import requests
@@ -44,7 +44,7 @@ def get_previous_quarter(day=None):
     Day should be of type datetime.date
     """
     if day is None:
-        day = date.today()
+        day = datetime.date.today()
     if 1 <= day.month <= 3:
         query_range = (
             f'((updated >= "{day.year-1}-10-01" AND updated <= "{day.year-1}-12-31")'

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -6,7 +6,7 @@ import os
 import random
 import re
 import smtplib
-from datetime import date
+import datetime
 from email.message import EmailMessage
 
 import requests
@@ -310,3 +310,29 @@ def get_fake_data(path="data/fake_data.json"):
     with open(path) as fake_data:
         data = json.load(fake_data)
     return data
+
+
+def make_headers(token):
+    """Builds the HTTP headers for API requests
+
+    Args:
+        token(str): A valid bearer token
+
+    Returns:
+        dict: valid headers for use with the requests module
+    """
+    headers = {"Accept": "application/json", "Authorization": "Bearer " + token}
+    return headers
+
+
+def format_date(the_date):
+    """Converts a date string in to the required format
+
+    Args:
+        date(str): A date stored as a string
+
+    Returns:
+        datetime.date: A datetime object
+    """
+    formatted_date = datetime.datetime.strptime(the_date, "%Y-%m-%dT%H:%M:%SZ")
+    return formatted_date


### PR DESCRIPTION
fixes around 10 sonar findings:
- variable shadows a builtin
- rename camelCase vars
- use `\d` instead of `[0-9]` in regex
- don't use `datetime.datetime.utcnow()`
- duplicated literals: rather than define constants, break out `make_header` and `format_date` functions for reuse

plus a couple of pylint findings.