### PR TITLE
address token expiration + rm debug statements

### DIFF
--- a/dashboard/src/t5gweb/taskmgr.py
+++ b/dashboard/src/t5gweb/taskmgr.py
@@ -74,7 +74,7 @@ def setup_scheduled_tasks(sender, **kwargs):
 
     # update Jira bug details cache
     sender.add_periodic_task(
-        crontab(hour="*", minute="54"),  # hourly + offset
+        crontab(hour="*/12", minute="54"),  # twice a day
         cache_data.s("issues"),
         name="issues_sync",
     )


### PR DESCRIPTION
Our tasks have been getting longer due to rate limits. As a result, our refresh token is expiring halfway through some of our tasks. This PR gets a new one upon expiration. 

Also reduces frequency of task.

In the future, we could create a wrapper around the requests object to automatically refresh the token when it detects a 401 error.