### PR TITLE
feature check previous issues

### DIFF
--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -67,9 +67,9 @@ def refresh(data_type):
     elif data_type == "issues":
         get_issue_details(cfg)
         return jsonify({"caching issues": "ok"})
-    elif data_type == "newcases":
+    elif data_type == "create_jira_cards":
         sync_portal_to_jira()
-        return jsonify({"newcases": "ok"})
+        return jsonify({"create_jira_cards": "ok"})
     elif data_type == "stats":
         get_stats()
         return jsonify({"caching stats": "ok"})

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -12,7 +12,7 @@ from t5gweb.cache import (
     get_issue_details,
     get_stats,
 )
-from t5gweb.libtelco5g import generate_stats, redis_get, redis_set
+from t5gweb.libtelco5g import generate_stats, redis_get, redis_set, sync_portal_to_jira
 from t5gweb.utils import set_cfg
 
 BP = Blueprint("api", __name__, url_prefix="/api")
@@ -67,6 +67,9 @@ def refresh(data_type):
     elif data_type == "issues":
         get_issue_details(cfg)
         return jsonify({"caching issues": "ok"})
+    elif data_type == "newcases":
+        sync_portal_to_jira()
+        return jsonify({"newcases": "ok"})
     elif data_type == "stats":
         get_stats()
         return jsonify({"caching stats": "ok"})

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -268,7 +268,7 @@ def create_cards(cfg, new_cases, action="none"):
         case_creation_date = datetime.datetime.strptime(cases[case]["createdate"], "%Y-%m-%dT%H:%M:%SZ")
         date_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         if(case_creation_date < date_now - datetime.timedelta(days=15)):
-            logging.warning("Case creatiion date anterior to 15 days ago, checking if it has previous owner of a jira card")
+            logging.warning("Case creation date more than 15 days ago, checking if it has previous owner of a jira card")
             previous_issue = get_previous_card(jira_conn, cfg, case)
             # Prepare the bulk edit payload
             logging.warning(f"Updating : {previous_issue.key} rather than creating a new card.")

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -269,12 +269,13 @@ def create_cards(cfg, new_cases, action="none"):
         if(case_creation_date < date_now - datetime.timedelta(days=15)):
             logging.warning("Case creation date more than 15 days ago, checking if it has previous owner of a jira card")
             previous_issue = get_previous_card(jira_conn, cfg, case)
-            # Prepare the bulk edit payload
-            logging.warning(f"Updating : {previous_issue.key} rather than creating a new card.")
-            jira_conn.add_issues_to_sprint(sprint.id, [previous_issue.key])
-            jira_conn.transition_issue(previous_issue, '11')
-            jira_conn.add_comment(previous_issue, f"Case {case} seems to have been reopened. The dashboard found this card linked to the case and reopened it automatically.")
-            continue
+            if(previous_issue is not None):
+                # Prepare the bulk edit payload
+                logging.warning(f"Updating : {previous_issue.key} rather than creating a new card.")
+                jira_conn.add_issues_to_sprint(sprint.id, [previous_issue.key])
+                jira_conn.transition_issue(previous_issue, '11')
+                jira_conn.add_comment(previous_issue, f"Case {case} seems to have been reopened. The dashboard found this card linked to the case and reopened it automatically.")
+                continue
         if cfg["team"]:
             for member in cfg["team"]:
                 for account in member["accounts"]:

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -271,7 +271,12 @@ def create_cards(cfg, new_cases, action="none"):
         else:
             novel_cases.append(case)
         assignee = None
-        previous_owner = get_previous_owner(jira_conn, cfg, case)
+        previous_owner = None
+        case_creation_date = datetime.datetime.strptime(cases[case]["createdate"], "%Y-%m-%dT%H:%M:%SZ")
+        date_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        if(case_creation_date < date_now - datetime.timedelta(days=15)):
+            logging.warning("Case creatiion date anterior to 15 days ago, checking if it has previous owner of a jira card")
+            previous_owner = get_previous_owner(jira_conn, cfg, case)
         if cfg["team"]:
             for member in cfg["team"]:
                 if previous_owner != None:


### PR DESCRIPTION
new feature to check previous cards related to a certain case number.
If a previous card is found, assign the new one to owner of the previous one.

I did test it on my local env, it seems to work but if you can double check on your env before merging it would be good