### PR TITLE
Send messages to appropriate slack channels

### DIFF
--- a/cfg/sample.cfg
+++ b/cfg/sample.cfg
@@ -96,8 +96,9 @@
 ; slack_token   : ''
 
 # Slack Channel ID
-# ID of the Slack Channel to send messages to.
-; slack_channel : '' 
+# ID of the Slack Channel to send high and low severity messages to.
+; high_severity_slack_channel : '' 
+; low_severity_slack_channel : ''
 
 ### Bugzilla API
 # Python Wrapper for BZ API: https://github.com/python-bugzilla/python-bugzilla

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -511,10 +511,7 @@ def generate_stats(account=None, engineer=None):
                 stats["escalated"] += 1
             if cards[card]["crit_sit"]:
                 stats["crit_sit"] += 1
-            if (
-                cards[card]["escalated"]
-                or cards[card]["crit_sit"]
-            ):
+            if cards[card]["escalated"] or cards[card]["crit_sit"]:
                 stats["total_escalations"] += 1
             if cards[card]["bugzilla"] is None and cards[card]["issues"] is None:
                 stats["no_bzs"] += 1
@@ -804,7 +801,9 @@ def sync_portal_to_jira():
             logging.warning("notifying team about new JIRA cards")
             cfg["subject"] += ": {}".format(", ".join(novel_cases))
             email_notify(cfg, message_content)
-            if cfg["slack_token"] and cfg["slack_channel"]:
+            if cfg["slack_token"] and (
+                cfg["high_severity_slack_channel"] or cfg["low_severity_slack_channel"]
+            ):
                 slack_notify(cfg, message_content)
             else:
                 logging.warning("no slack token or channel specified")

--- a/dashboard/src/tests/test_utils.py
+++ b/dashboard/src/tests/test_utils.py
@@ -86,6 +86,7 @@ def test_set_default():
         "case_closedDate",
     ]
     assert defaults["slack_token"] == ""
-    assert defaults["slack_channel"] == ""
+    assert defaults["high_severity_slack_channel"] == ""
+    assert defaults["low_severity_slack_channel"] == ""
     assert defaults["max_jira_results"] == 1000
     assert defaults["max_portal_results"] == 5000


### PR DESCRIPTION
Instead of sending slack messages to one channel, send to different channels based on their severity.