### PR TITLE
Reorganize notification code

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -225,7 +225,6 @@ def create_cards(cfg, new_cases, action="none"):
     needed - list of cases that need a card created
     """
 
-    email_content = []
     new_cards = {}
 
     logging.warning("attempting to connect to jira...")
@@ -318,23 +317,9 @@ def create_cards(cfg, new_cases, action="none"):
             # Updating the card with the Release_Note_Text field.
             new_card.update(fields={"customfield_12317313": "TRACK"})
             logging.warning("created {}".format(new_card.key))
-
-            email_content.append(
-                (
-                    f"A JIRA issue ({cfg['server']}/browse/{new_card}) has been created"
-                    f" for a new case:\n"
-                    f"Case #: {case} (https://access.redhat.com/support/cases/{case})\n"
-                    f"Account: {cases[case]['account']}\n"
-                    f"Summary: {cases[case]['problem']}\n"
-                    f"Severity: {cases[case]['severity']}\n"
-                    f"Description: {cases[case]['description']}\n"
-                )
+            notification_content = generate_notification_content(
+                cfg, assignee, new_card, case, cases
             )
-            if assignee:
-                email_content.append(
-                    f"It is initially being tracked by {assignee['name']}.\n"
-                )
-            email_content.append("\n===========================================\n\n")
 
             # Add newly create card to the sprint
             if cfg["sprintname"] and cfg["sprintname"] != "":
@@ -396,7 +381,48 @@ def create_cards(cfg, new_cases, action="none"):
                 "crit_sit": False,
             }
 
-    return email_content, new_cards, novel_cases
+    return notification_content, new_cards, novel_cases
+
+
+def generate_notification_content(cfg, assignee, new_card, case, cases):
+    """Generate notification message for email's and Slack
+
+    Args:
+        assignee (dict): Information about the card's assignee
+        new_card (str): Name of created JIRA card
+        case (str): ID of relevant case
+        cases (dict): Contains further information about cases
+
+    Returns:
+        dict: Notification message and extra information to construct slack message.
+    """
+    notification_content = {}
+    if assignee:
+        assignee_section = f"It is initially being tracked by {assignee['name']}."
+    else:
+        assignee_section = "It is not assigned to anyone."
+    notification_content[new_card] = {}
+    notification_content[new_card]["body"] = (
+        f"A JIRA issue ({cfg['server']}/browse/{new_card}) has been created"
+        f" for a new case:\n"
+        f"Case #: {case} (https://access.redhat.com/support/cases/{case})\n"
+        f"Account: {cases[case]['account']}\n"
+        f"Summary: {cases[case]['problem']}\n"
+        f"Severity: {cases[case]['severity']}\n"
+        f"{assignee_section}\n"
+    )
+    notification_content[new_card]["severity"] = cases[case]["severity"]
+    notification_content[new_card][
+        "description"
+    ] = f"Description: {cases[case]['description']}\n"
+    notification_content[new_card]["assignee"] = assignee["name"] if assignee else None
+    notification_content[new_card]["full_message"] = (
+        notification_content[new_card]["body"]
+        + "\n"
+        + notification_content[new_card]["description"]
+        + "\n===========================================\n\n"
+    )
+    return notification_content
 
 
 def redis_set(key, value):
@@ -776,35 +802,32 @@ def sync_portal_to_jira():
     response = {"cards_created": 0}
 
     if len(new_cases) > int(cfg["max_to_create"]):
-        logging.warning(
-            (
-                f"Warning: more than {cfg['max_to_create']} cases ({len(new_cases)}) "
-                f"will be created, so refusing to proceed. Please check log output\n"
-            )
+        max_warning_message = (
+            f"Warning: more than {cfg['max_to_create']} cases ({len(new_cases)}) "
+            f"will be created, so refusing to proceed. Please check log output\n"
         )
-        email_content = [
-            (
-                f"Warning: more than {cfg['max_to_create']} cases ({len(new_cases)})"
-                f"will be created, so refusing to proceed. Please check log output\n"
-            )
-        ]
-        email_content += ['New cases: {}\n"'.format(new_cases)]
+        logging.warning(max_warning_message)
+        notification_content = {
+            "High New Case Count Detected": {
+                "full_message": (f"{max_warning_message}\nNew cases: {new_cases}\n")
+            }
+        }
         cfg["to"] = cfg["alert_email"]
         cfg["subject"] = "High New Case Count Detected"
-        email_notify(cfg, email_content)
+        email_notify(cfg, notification_content)
     elif len(new_cases) > 0:
         logging.warning("need to create {} cases".format(len(new_cases)))
-        message_content, new_cards, novel_cases = create_cards(
+        notification_content, new_cards, novel_cases = create_cards(
             cfg, new_cases, action="create"
         )
-        if message_content:
+        if notification_content:
             logging.warning("notifying team about new JIRA cards")
             cfg["subject"] += ": {}".format(", ".join(novel_cases))
-            email_notify(cfg, message_content)
+            email_notify(cfg, notification_content)
             if cfg["slack_token"] and (
                 cfg["high_severity_slack_channel"] or cfg["low_severity_slack_channel"]
             ):
-                slack_notify(cfg, message_content)
+                slack_notify(cfg, notification_content)
             else:
                 logging.warning("no slack token or channel specified")
             cards.update(new_cards)

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -14,12 +14,12 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 
-def email_notify(ini, blist, recipient=None, subject=None):
+def email_notify(ini, message_content, recipient=None, subject=None):
     """send an email to notify the team of a new case"""
 
     body = ""
-    for line in blist:
-        body += f"{line}\n"
+    for card in message_content:
+        body += message_content[card]["full_message"]
 
     msg = EmailMessage()
     msg.set_content(body)
@@ -245,45 +245,42 @@ def set_defaults():
     return defaults
 
 
-def slack_notify(ini, blist):
+def slack_notify(ini, notification_content):
     """notify the team of new cases via slack"""
-    body = ""
-    for line in blist:
-        body += f"{line}\n"
 
     client = WebClient(token=ini["slack_token"])
-    msgs = re.split(
-        r"A JIRA issue \(" + ini["server"] + r"\/browse\/|Description: ", body
-    )
 
-    # Adding the text removed by re.split() and adding ping to assignee
-    for i in range(1, len(msgs)):
-        if i % 2 == 1:
-            msgs[i] = "A JIRA issue (" + ini["server"] + "/browse/" + msgs[i]
-        if i % 2 == 0:
-            msgs[i] = "Description: " + msgs[i]
-            assign = re.findall(
-                r"(?<=\nIt is initially being tracked by )[\w ]*", msgs[i]
-            )
-            for j in ini["team"]:
-                if j["name"] == assign[0]:
-                    userid = j["slack_user"]
-            msgs[i] = re.sub(r"\nIt is initially being tracked by.*", "", msgs[i])
-            msgs[i - 1] = (
-                msgs[i - 1] + f"\nIt is initially being tracked by <@{userid}>"
+    for card in notification_content:
+        body = notification_content[card]["body"]
+
+        user_id = None
+        if notification_content[card]["assignee"]:
+            for member in ini["team"]:
+                if member["name"] == notification_content[card]["assignee"]:
+                    user_id = member["slack_user"]
+
+        # Add ping
+        if user_id:
+            body = re.sub(
+                r"It is initially being tracked by.*",
+                f"It is initially being tracked by <@{user_id}>",
+                body,
+                1,
             )
 
-    # Posting Summaries + reply with Description
-    for k in range(1, len(msgs) - 1, 2):
-        severity = re.search(r"Severity:\s*(\d+)", msgs[k])  # Get severity number
-        if severity and int(severity.group(1)) < 3:
+        # Get severity #. Ex: "3 (Normal)" => "3"
+        severity = re.search(r"\d+", notification_content[card]["severity"])
+        description = notification_content[card]["description"]
+
+        # Posting Summaries + reply with Description
+        if severity and int(severity.group()) < 3:
             channel = ini["high_severity_slack_channel"]
         else:
             channel = ini["low_severity_slack_channel"]
         try:
-            message = client.chat_postMessage(channel=channel, text=msgs[k])
+            message = client.chat_postMessage(channel=channel, text=body)
             client.chat_postMessage(
-                channel=channel, text=msgs[k + 1], thread_ts=message["ts"]
+                channel=channel, text=description, thread_ts=message["ts"]
             )
         except SlackApiError as slack_error:
             logging.warning("failed to post to slack: %s", slack_error)


### PR DESCRIPTION
We were seeing some bugs in slack. Sometimes messages weren't sent because we were using Regex to format slack messages. If a customer message had text that matched our regex searches, it would cause an error and messages wouldn't be sent. I've reorganized the email and slack code to make it less reliant on regex.