### PR TITLE
Update linter versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,16 +28,16 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v6
+        uses: super-linter/super-linter/slim@v7
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_HTML: false
-          JAVASCRIPT_DEFAULT_STYLE: prettier
+          VALIDATE_JAVASCRIPT_PRETTIER: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KUBERNETES_KUBECONFORM_OPTIONS: -ignore-missing-schemas
           # plugins.js contains different datatables plugins that we are self-hosting
-          # rather than using CDN/NPM, as described here: 
+          # rather than using CDN/NPM, as described here:
           # https://datatables.net/plug-ins/sorting/natural#Browser
           FILTER_REGEX_EXCLUDE: plugins\.js
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
 repos:
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
+    rev: 24.10.0
     hooks:
       - id: black
 
   # isort
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: [--profile=black]
 
   # flake8
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: [--config=.github/linters/.flake8]
 
   # gitleaks
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.2
+    rev: v8.21.2
     hooks:
       - id: gitleaks
 


### PR DESCRIPTION
- Update linters to newest versions
- Remove `JAVASCRIPT_DEFAULT_STYLE: prettier` because it's deprecated. 
- Set `VALIDATE_JAVASCRIPT_PRETTIER: false` in favor of StandardJS