### PR TITLE
use a local.env file instead of sample.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prerequisites:
 
 ### Steps
 
-1. If you are interested in setting up the backend services, fill out `cfg/sample.env`
+1. If you are interested in setting up the backend services, copy `cfg/sample.env` into `cfg/local.env`fill out with your details.
 with any relevant details.
 2. Run `cd dashboard` and `podman-compose up -d`
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Prerequisites:
 
 ### Steps
 
-1. If you are interested in setting up the backend services, copy `cfg/sample.env` into `cfg/local.env`fill out with your details.
-with any relevant details.
+1. If you are interested in setting up the backend services, copy `cfg/sample.env` into `cfg/local.env` and fill out with your details.
+
 2. Run `cd dashboard` and `podman-compose up -d`
 
 After it's built, you can access the dashboard at <localhost:8080/home>, and the Flower

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -13,11 +13,11 @@ services:
     build: .
     command: bash -c "gunicorn --bind 0.0.0.0:8080 --timeout 1200 wsgi:app --reload"
     env_file:
-      - ../cfg/sample.env
+      - ../cfg/local.env
     ports:
       - 8080:8080
     environment:
-      - FLASK_LOGIN_DISABLED=true  # Disable SSO Login for dev environments
+      - FLASK_LOGIN_DISABLED=true # Disable SSO Login for dev environments
       - FLASK_DEBUG=true
     depends_on:
       - redis
@@ -35,7 +35,7 @@ services:
     image: localhost/dashboard
     command: bash -c "flask init-cache"
     env_file:
-      - ../cfg/sample.env
+      - ../cfg/local.env
     depends_on:
       - redis
 
@@ -44,7 +44,7 @@ services:
     image: localhost/dashboard
     command: celery -A t5gweb.taskmgr worker --loglevel=info -E
     env_file:
-      - ../cfg/sample.env
+      - ../cfg/local.env
     depends_on:
       - redis
 
@@ -53,7 +53,7 @@ services:
     image: localhost/dashboard
     command: celery -A t5gweb.taskmgr beat -s /tmp/schedule
     env_file:
-      - ../cfg/sample.env
+      - ../cfg/local.env
     depends_on:
       - redis
 
@@ -64,7 +64,7 @@ services:
     ports:
       - 8000:8080
     env_file:
-      - ../cfg/sample.env
+      - ../cfg/local.env
     depends_on:
       - redis
 


### PR DESCRIPTION
Updating the sample.env with secrets bears the risk of accidentally committing them and using a local.env file instead (ignored by .gitignore already) makes development more convenient - no need to keep stashing those changes to sample.env before committing any new code.