### PR TITLE
Make child rows searchable

### DIFF
--- a/dashboard/src/t5gweb/templates/macros/macros.html
+++ b/dashboard/src/t5gweb/templates/macros/macros.html
@@ -95,10 +95,11 @@
                             {% elif new_comments[account][status][card]['severity'] == 'Urgent' %}
                                 {% set severity_order = 4 %}
                             {% endif %}
-                            <!-- data-child-data must be wrapped in SINGLE quotes.
-                                Otherwise, our JS can't parse the data. -->
-                            <tr data-child-data='{{ new_comments[account][status][card] | tojson }}'>
-                                <td class="align-middle dt-control"></td>
+                            <tr data-child-data="{{ new_comments[account][status][card] | tojson | forceescape }}">
+                                <td
+                                    class="align-middle dt-control"
+                                    data-search="{{ new_comments[account][status][card] | tojson | forceescape }}">
+                                </td>
                                 <td class="align-middle text-center">
                                     <a href="https://access.redhat.com/support/cases/#/case/{{ new_comments[account][status][card]['case_number'] }}"
                                     target="_blank">{{ new_comments[account][status][card]['case_number'] }}</a>


### PR DESCRIPTION
- Fixes #227
- Now, the search box on tables will also search through child rows, in addition to parent rows.
- See [docs](https://datatables.net/manual/data/index#DOM) for details
- Assisted by GPT 5.3 Codex/Claude