### PR TITLE
New private keywords

### DIFF
--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -1028,7 +1028,7 @@ def _extract_private_keywords(bug):
     """
     try:
         private_keywords_raw = (
-            bug.renderedFields.customfield_11165
+            bug.renderedFields.customfield_11087
         )  # RH Private Keywords
     except AttributeError:
         return None

--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -1028,7 +1028,7 @@ def _extract_private_keywords(bug):
     """
     try:
         private_keywords_raw = (
-            bug.renderedFields.customfield_10999
+            bug.renderedFields.customfield_11165
         )  # RH Private Keywords
     except AttributeError:
         return None

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -1370,7 +1370,7 @@ def tag_bz():
     tagging actions.
 
     For Bugzilla bugs, updates the internal_whiteboard field.
-    For JIRA bugs, updates the Private Keywords (customfield_10999) field
+    For JIRA bugs, updates the Private Keywords (customfield_11165) field
     or falls back to Internal Whiteboard (customfield_11004) if Private
     Keywords is not available.
 
@@ -1444,7 +1444,7 @@ def tag_bz():
                     )
                     try:
                         # RH Private Keywords custom field
-                        private_keywords = card.renderedFields.customfield_10999
+                        private_keywords = card.renderedFields.customfield_11165
                     except AttributeError:
                         logging.warning(
                             "No Private Keywords field for {}, skipping".format(
@@ -1466,7 +1466,7 @@ def tag_bz():
                         if "Telco" not in new_keywords:
                             new_keywords += "Telco,Telco:Case"
                             logging.warning("tagging Jira Bug:" + str(card))
-                            card.update(fields={"customfield_10999": new_keywords})
+                            card.update(fields={"customfield_11165": new_keywords})
                             num_tagged += 1
                             email_body["Script Tagged Private Keywords"][
                                 "cards"
@@ -1474,7 +1474,7 @@ def tag_bz():
                         elif "Telco:Case" not in new_keywords:
                             new_keywords += "Telco:Case"
                             logging.warning("tagging Jira Bug:" + str(card))
-                            card.update(fields={"customfield_10999": new_keywords})
+                            card.update(fields={"customfield_11165": new_keywords})
                             num_tagged += 1
                             email_body["Script Tagged Private Keywords"][
                                 "cards"

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -1461,8 +1461,10 @@ def tag_bz():
                         if private_keywords is None:
                             private_keywords = ""
                         new_keywords = private_keywords
+                        if new_keywords:
+                            new_keywords += ","
                         if "Telco" not in new_keywords:
-                            new_keywords += ",Telco,Telco:Case"
+                            new_keywords += "Telco,Telco:Case"
                             logging.warning("tagging Jira Bug:" + str(card))
                             card.update(fields={"customfield_10999": new_keywords})
                             num_tagged += 1
@@ -1470,7 +1472,7 @@ def tag_bz():
                                 "cards"
                             ].append(str(card))
                         elif "Telco:Case" not in new_keywords:
-                            new_keywords += ",Telco:Case"
+                            new_keywords += "Telco:Case"
                             logging.warning("tagging Jira Bug:" + str(card))
                             card.update(fields={"customfield_10999": new_keywords})
                             num_tagged += 1

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -1370,7 +1370,7 @@ def tag_bz():
     tagging actions.
 
     For Bugzilla bugs, updates the internal_whiteboard field.
-    For JIRA bugs, updates the Private Keywords (customfield_11165) field
+    For JIRA bugs, updates the Private Keywords (customfield_11087) field
     or falls back to Internal Whiteboard (customfield_11004) if Private
     Keywords is not available.
 
@@ -1444,7 +1444,7 @@ def tag_bz():
                     )
                     try:
                         # RH Private Keywords custom field
-                        private_keywords = card.renderedFields.customfield_11165
+                        private_keywords = card.renderedFields.customfield_11087
                     except AttributeError:
                         logging.warning(
                             "No Private Keywords field for {}, skipping".format(
@@ -1466,7 +1466,7 @@ def tag_bz():
                         if "Telco" not in new_keywords:
                             new_keywords += "Telco,Telco:Case"
                             logging.warning("tagging Jira Bug:" + str(card))
-                            card.update(fields={"customfield_11165": new_keywords})
+                            card.update(fields={"customfield_11087": new_keywords})
                             num_tagged += 1
                             email_body["Script Tagged Private Keywords"][
                                 "cards"
@@ -1474,7 +1474,7 @@ def tag_bz():
                         elif "Telco:Case" not in new_keywords:
                             new_keywords += "Telco:Case"
                             logging.warning("tagging Jira Bug:" + str(card))
-                            card.update(fields={"customfield_11165": new_keywords})
+                            card.update(fields={"customfield_11087": new_keywords})
                             num_tagged += 1
                             email_body["Script Tagged Private Keywords"][
                                 "cards"


### PR DESCRIPTION
- Remove unnecessary leading comma when private_keywords is empty (",Telco,Telco:case" => "Telco,Telco:case")
- Update private keywords field ID, as the Jira team have updated it to make better for querying etc.