### PR TITLE
Level out case assignment

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import logging
 import os
+import random
 import re
 import statistics
 import time
@@ -23,7 +24,6 @@ from t5gweb.utils import (
     email_notify,
     exists_or_zero,
     format_date,
-    get_random_member,
     get_token,
     make_headers,
     set_cfg,
@@ -348,13 +348,14 @@ def create_cards(cfg, new_cases, action="none"):
 
     # Filter cases that need cards
     novel_cases = _filter_novel_cases(new_cases, context["created_cases"])
+    assignments = _assign_cases_batch(novel_cases, cases, cfg)
 
     # Process each case
     new_cards = {}
     notification_content = {}
 
     for case in novel_cases:
-        result = _process_single_case(case, cases, context, cfg)
+        result = _process_single_case(case, cases, context, cfg, assignments[case])
         if result:
             new_cards[result["card_key"]] = result["card_data"]
             notification_content[result["card_key"]] = result["notification"]
@@ -458,7 +459,7 @@ def _notify_slack_error(cfg, case, error_msg):
         logging.error(f"Failed to send Slack error notification: {slack_err}")
 
 
-def _process_single_case(case, cases, context, cfg):
+def _process_single_case(case, cases, context, cfg, assignee):
     """Process a single case and create its JIRA card
 
     Handles the complete workflow for creating a JIRA card from a case,
@@ -470,6 +471,8 @@ def _process_single_case(case, cases, context, cfg):
         cases: Dictionary of all case data
         context: Context dictionary from _setup_card_creation_context
         cfg: Configuration dictionary
+        assignee: Pre-determined team member dict from _assign_cases_batch,
+            or None if no team is configured
 
     Returns:
         dict: Dictionary containing 'card_key', 'card_data', and 'notification'
@@ -479,9 +482,6 @@ def _process_single_case(case, cases, context, cfg):
     if _is_old_case(cases[case]):
         if _handle_old_case(case, context, cfg):
             return None  # Case was handled by reopening existing card
-
-    # Determine assignee
-    assignee = _determine_assignee(case, cases, cfg)
 
     # Add watcher if needed
     if assignee and assignee.get("notifieduser", "true") == "true":
@@ -566,42 +566,69 @@ def _handle_old_case(case, context, cfg):
     return False
 
 
-def _determine_assignee(case, cases, cfg):
-    """Determine who should be assigned to the case
+def _assign_cases_batch(novel_cases, cases, cfg):
+    """Assign all new cases to engineers in one pass.
 
-    Matches case to team member based on account assignment. If no match is
-    found, assigns randomly to a team member using round-robin logic.
+    Account-matched cases are assigned first. For the remaining unmatched cases:
+    - If total cases <= team size, account-assigned engineers are excluded from
+      the round-robin pool and each remaining engineer gets at most one case.
+    - If total cases > team size, all engineers are eligible (account-assigned
+      ones included) and the pool cycles as needed.
 
     Args:
-        case: Case number to assign
+        novel_cases: Ordered list of case numbers to assign
         cases: Dictionary of all case data
         cfg: Configuration dictionary containing team member information
 
     Returns:
-        dict: Team member dictionary with assignment info, or None if no team
-            configured
+        dict: Mapping of case number -> team member dict (or None if no team)
     """
     if not cfg["team"]:
-        return None
+        return {case: None for case in novel_cases}
 
-    # Try to match by account
-    team = [
-        member
-        for member in cfg["team"]
-        if member.get("active", "true").lower() == "true"
-    ]
-    for member in team:
-        for account in member["accounts"]:
-            if account.lower() in cases[case]["account"].lower():
-                member["displayName"] = member["name"]
-                return member
+    team = [m for m in cfg["team"] if m.get("active", "true").lower() == "true"]
+    assignments = {}
+    unmatched = []
+    account_assigned_ids = set()
 
-    # No match found, assign randomly
-    last_choice = redis_get("last_choice")
-    assignee = get_random_member(team, last_choice)
-    redis_set("last_choice", json.dumps(assignee))
-    assignee["displayName"] = assignee["name"]
-    return assignee
+    for case in novel_cases:
+        matched = next(
+            (
+                m for m in team
+                if any(acct.lower() in cases[case]["account"].lower() for acct in m["accounts"])
+            ),
+            None,
+        )
+        if matched:
+            member = dict(matched)
+            member["displayName"] = member["name"]
+            assignments[case] = member
+            account_assigned_ids.add(matched["jira_account_id"])
+        else:
+            unmatched.append(case)
+
+    if not unmatched:
+        return assignments
+
+    if len(novel_cases) <= len(team):
+        # Enough engineers to give everyone at most one case — exclude those
+        # already assigned via account matching
+        available = [m for m in team if m["jira_account_id"] not in account_assigned_ids]
+    else:
+        available = team
+
+    pool = random.sample(available, len(available))
+
+    # If unmatched cases fit within the pool, no engineer gets a second case
+    if len(unmatched) <= len(pool):
+        pool = pool[: len(unmatched)]
+
+    for i, case in enumerate(unmatched):
+        member = dict(pool[i % len(pool)])
+        member["displayName"] = member["name"]
+        assignments[case] = member
+
+    return assignments
 
 
 def _build_card_info(case, cases, cfg, assignee):

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -614,9 +614,9 @@ def _assign_cases_batch(novel_cases, cases, cfg):
     if not unmatched:
         return assignments
 
-    if len(novel_cases) <= len(team):
-        # Enough engineers to give everyone at most one case — exclude those
-        # already assigned via account matching
+    if len(unmatched) <= len(team):
+        # Fewer unmatched cases than engineers — exclude account-assigned ones
+        # so no engineer gets more than one case in this batch
         available = [
             m for m in team if m["jira_account_id"] not in account_assigned_ids
         ]

--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -594,8 +594,12 @@ def _assign_cases_batch(novel_cases, cases, cfg):
     for case in novel_cases:
         matched = next(
             (
-                m for m in team
-                if any(acct.lower() in cases[case]["account"].lower() for acct in m["accounts"])
+                m
+                for m in team
+                if any(
+                    acct.lower() in cases[case]["account"].lower()
+                    for acct in m["accounts"]
+                )
             ),
             None,
         )
@@ -613,7 +617,9 @@ def _assign_cases_batch(novel_cases, cases, cfg):
     if len(novel_cases) <= len(team):
         # Enough engineers to give everyone at most one case — exclude those
         # already assigned via account matching
-        available = [m for m in team if m["jira_account_id"] not in account_assigned_ids]
+        available = [
+            m for m in team if m["jira_account_id"] not in account_assigned_ids
+        ]
     else:
         available = team
 

--- a/dashboard/src/t5gweb/utils.py
+++ b/dashboard/src/t5gweb/utils.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import logging
 import os
-import random
 import re
 import smtplib
 from email.message import EmailMessage
@@ -66,35 +65,6 @@ def exists_or_zero(data, key):
     if key in data.keys():
         return data[key]
     return 0
-
-
-def get_random_member(team, last_choice=None):
-    """Randomly select a team member for case assignment
-
-    Selects a random team member from the provided list, with logic to avoid
-    assigning to the same person consecutively when multiple team members are
-    available.
-
-    Args:
-        team: List of team member dictionaries
-        last_choice: Previously selected team member to avoid reselecting.
-            Defaults to None.
-
-    Returns:
-        dict: Randomly selected team member dictionary, or None if team is empty
-    """
-
-    if len(team) > 1:
-        if last_choice is not None:
-            team = [member for member in team if member != last_choice]
-        current_choice = random.choice(team)
-    elif len(team) == 1:
-        current_choice = team[0]
-    else:
-        logging.warning("No team variable is available, cannot assign case.")
-        current_choice = None
-
-    return current_choice
 
 
 def get_token(offline_token):

--- a/dashboard/src/tests/test_libtelco5g.py
+++ b/dashboard/src/tests/test_libtelco5g.py
@@ -147,18 +147,16 @@ def test_account_assigned_engineers_excluded_when_cases_lte_team(team, cases):
 
 
 def test_multiple_account_cases_still_exclude_their_engineers(team, cases):
-    # 4 cases, 3 engineers: 001+002->Alice, 003->Bob, 004 must go to Carol
-    # Even though Alice got 2 cases via account, she is still excluded from round-robin
-    # because total cases (4) > team size (3), BUT account-matched engineers
-    # are only excluded when cases <= team — here 4 > 3 so all engineers are eligible
+    # 4 cases, 3 engineers: 001+002->Alice, 003->Bob, 1 unmatched case (004)
+    # 1 unmatched <= 3 team size, so account-assigned engineers are excluded —
+    # 004 must go to Carol (the only non-account-assigned engineer)
     cfg = {"team": team}
-    all_ids = {"a1", "b1", "c1"}
     result = _assign_cases_batch(["001", "002", "003", "004"], cases, cfg)
 
     assert result["001"]["jira_account_id"] == "a1"
     assert result["002"]["jira_account_id"] == "a1"
     assert result["003"]["jira_account_id"] == "b1"
-    assert result["004"]["jira_account_id"] in all_ids
+    assert result["004"]["jira_account_id"] == "c1"
 
 
 def test_account_assigned_engineers_excluded_even_with_multiple_account_cases(

--- a/dashboard/src/tests/test_libtelco5g.py
+++ b/dashboard/src/tests/test_libtelco5g.py
@@ -1,5 +1,6 @@
 import pytest
 from t5gweb.libtelco5g import (
+    _assign_cases_batch,
     get_case_number,
     is_bug_missing_target,
     jira_connection,
@@ -81,3 +82,96 @@ def test_get_case_number(link, pfilter, expected_case_number):
 def test_is_bug_missing_target(item, expected_result):
     result = is_bug_missing_target(item)
     assert result == expected_result
+
+
+# --- _assign_cases_batch tests ---
+
+@pytest.fixture
+def team():
+    return [
+        {"name": "Alice", "jira_account_id": "a1", "jira_user": "alice", "accounts": ["Acme"], "active": "true"},
+        {"name": "Bob",   "jira_account_id": "b1", "jira_user": "bob",   "accounts": ["Globex"], "active": "true"},
+        {"name": "Carol", "jira_account_id": "c1", "jira_user": "carol", "accounts": [], "active": "true"},
+    ]
+
+
+@pytest.fixture
+def cases():
+    return {
+        "001": {"account": "Acme Corp"},
+        "002": {"account": "Acme Corp"},
+        "003": {"account": "Globex Inc"},
+        "004": {"account": "Unknown LLC"},
+        "005": {"account": "Another Co"},
+        "006": {"account": "Yet Another"},
+    }
+
+
+def test_multiple_cases_same_account_go_to_same_engineer(team, cases):
+    # 001 and 002 are both Acme — both must land on Alice
+    cfg = {"team": team}
+    result = _assign_cases_batch(["001", "002"], cases, cfg)
+
+    assert result["001"]["jira_account_id"] == "a1"
+    assert result["002"]["jira_account_id"] == "a1"
+
+
+def test_account_assigned_engineers_excluded_when_cases_lte_team(team, cases):
+    # 3 cases <= 3 engineers: 001->Alice, 003->Bob, 004 must go to Carol (not Alice/Bob)
+    cfg = {"team": team}
+    result = _assign_cases_batch(["001", "003", "004"], cases, cfg)
+
+    assert result["001"]["jira_account_id"] == "a1"
+    assert result["003"]["jira_account_id"] == "b1"
+    assert result["004"]["jira_account_id"] == "c1"
+
+
+def test_multiple_account_cases_still_exclude_their_engineers(team, cases):
+    # 4 cases, 3 engineers: 001+002->Alice, 003->Bob, 004 must go to Carol
+    # Even though Alice got 2 cases via account, she is still excluded from round-robin
+    # because total cases (4) > team size (3), BUT account-matched engineers
+    # are only excluded when cases <= team — here 4 > 3 so all engineers are eligible
+    cfg = {"team": team}
+    all_ids = {"a1", "b1", "c1"}
+    result = _assign_cases_batch(["001", "002", "003", "004"], cases, cfg)
+
+    assert result["001"]["jira_account_id"] == "a1"
+    assert result["002"]["jira_account_id"] == "a1"
+    assert result["003"]["jira_account_id"] == "b1"
+    assert result["004"]["jira_account_id"] in all_ids
+
+
+def test_account_assigned_engineers_excluded_even_with_multiple_account_cases(team, cases):
+    # 3 cases <= 3 engineers: 001+002 both go to Alice via account,
+    # 004 is unmatched — pool must exclude Alice, so Carol gets it
+    cfg = {"team": team}
+    result = _assign_cases_batch(["001", "002", "004"], cases, cfg)
+
+    assert result["001"]["jira_account_id"] == "a1"
+    assert result["002"]["jira_account_id"] == "a1"
+    assert result["004"]["jira_account_id"] in {"b1", "c1"}
+
+
+def test_overflow_reuses_all_engineers(team, cases):
+    # 6 cases, 3 engineers — must cycle, all engineers used
+    cfg = {"team": team}
+    result = _assign_cases_batch(["001", "002", "003", "004", "005", "006"], cases, cfg)
+
+    assert len(result) == 6
+    assigned_ids = {a["jira_account_id"] for a in result.values()}
+    assert assigned_ids == {"a1", "b1", "c1"}
+
+
+def test_no_team_returns_none_for_all_cases(cases):
+    cfg = {"team": []}
+    result = _assign_cases_batch(["004", "005"], cases, cfg)
+
+    assert result == {"004": None, "005": None}
+
+
+def test_displayname_always_set(team, cases):
+    cfg = {"team": team}
+    result = _assign_cases_batch(["001", "002", "004"], cases, cfg)
+
+    for assignee in result.values():
+        assert assignee["displayName"] == assignee["name"]

--- a/dashboard/src/tests/test_libtelco5g.py
+++ b/dashboard/src/tests/test_libtelco5g.py
@@ -1,4 +1,5 @@
 import pytest
+
 from t5gweb.libtelco5g import (
     _assign_cases_batch,
     get_case_number,
@@ -86,12 +87,31 @@ def test_is_bug_missing_target(item, expected_result):
 
 # --- _assign_cases_batch tests ---
 
+
 @pytest.fixture
 def team():
     return [
-        {"name": "Alice", "jira_account_id": "a1", "jira_user": "alice", "accounts": ["Acme"], "active": "true"},
-        {"name": "Bob",   "jira_account_id": "b1", "jira_user": "bob",   "accounts": ["Globex"], "active": "true"},
-        {"name": "Carol", "jira_account_id": "c1", "jira_user": "carol", "accounts": [], "active": "true"},
+        {
+            "name": "Alice",
+            "jira_account_id": "a1",
+            "jira_user": "alice",
+            "accounts": ["Acme"],
+            "active": "true",
+        },
+        {
+            "name": "Bob",
+            "jira_account_id": "b1",
+            "jira_user": "bob",
+            "accounts": ["Globex"],
+            "active": "true",
+        },
+        {
+            "name": "Carol",
+            "jira_account_id": "c1",
+            "jira_user": "carol",
+            "accounts": [],
+            "active": "true",
+        },
     ]
 
 
@@ -141,7 +161,9 @@ def test_multiple_account_cases_still_exclude_their_engineers(team, cases):
     assert result["004"]["jira_account_id"] in all_ids
 
 
-def test_account_assigned_engineers_excluded_even_with_multiple_account_cases(team, cases):
+def test_account_assigned_engineers_excluded_even_with_multiple_account_cases(
+    team, cases
+):
     # 3 cases <= 3 engineers: 001+002 both go to Alice via account,
     # 004 is unmatched — pool must exclude Alice, so Carol gets it
     cfg = {"team": team}

--- a/dashboard/src/tests/test_utils.py
+++ b/dashboard/src/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
-from t5gweb.utils import exists_or_zero, get_random_member, set_defaults
+
+from t5gweb.utils import exists_or_zero, set_defaults
 
 
 @pytest.mark.parametrize(
@@ -14,38 +15,6 @@ from t5gweb.utils import exists_or_zero, get_random_member, set_defaults
 def test_exists_or_zero(data, key, expected):
     data_point = exists_or_zero(data, key)
     assert data_point == expected
-
-
-@pytest.fixture
-def sample_team():
-    return ["Alice", "Bob", "Charlie", "David"]
-
-
-def test_get_random_member_basic(sample_team):
-    result = get_random_member(sample_team)
-    assert result in sample_team
-
-
-def test_get_random_member_avoid_same_person_twice(sample_team):
-    first_choice = get_random_member(sample_team)
-    second_choice = get_random_member(sample_team, last_choice=first_choice)
-
-    assert first_choice in sample_team
-    assert second_choice in sample_team
-    assert first_choice != second_choice
-
-
-def test_get_random_member_single_member():
-    team = ["Alice"]
-    result = get_random_member(team)
-    assert result == "Alice"
-
-
-def test_get_random_member_empty_team_with_warning(caplog):
-    team = []
-    result = get_random_member(team)
-    assert result is None
-    assert "No team variable is available, cannot assign case." in caplog.text
 
 
 def test_set_default():


### PR DESCRIPTION
adds a new algorithm to case assignment for a fairer distribution of new cases

- assignment happens for the entire batch of new cases to reduce how the simple random assignment resulted in disproportionate amounts of cases assigned.
-  the algorithm assigns cases to engineers with accounts tied to their ID, then depending on the number of remaining cases, removes or keeps them in the random assignment loop
- the PR also contains a few possible test cases.

* assisted by Claude