### PR TITLE
 Add support for persisting Red Hat Portal case comments to PostgreSQL database.

### DIFF
--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -12,7 +12,7 @@ import requests
 from jira.exceptions import JIRAError
 
 from t5gweb import libtelco5g
-from t5gweb.database import load_cases_postgres, load_jira_card_postgres
+from t5gweb.database import load_cases_postgres, load_comments_postgres, load_jira_card_postgres
 from t5gweb.utils import format_comment, format_date, make_headers
 
 
@@ -618,11 +618,12 @@ def get_case_details(cfg):
                 headers = make_headers(token)
                 r_case = requests.get(case_endpoint, headers=headers)
 
-            crit_sit = r_case.json().get("critSit", False)
-            group_name = r_case.json().get("groupName", None)
-            notified_users = r_case.json().get("notifiedUsers", [])
-            relief_at = r_case.json().get("reliefAt", None)
-            resolved_at = r_case.json().get("resolvedAt", None)
+            case_json = r_case.json()
+            crit_sit = case_json.get("critSit", False)
+            group_name = case_json.get("groupName", None)
+            notified_users = case_json.get("notifiedUsers", [])
+            relief_at = case_json.get("reliefAt", None)
+            resolved_at = case_json.get("resolvedAt", None)
 
             case_details[case] = {
                 "crit_sit": crit_sit,
@@ -632,7 +633,15 @@ def get_case_details(cfg):
                 "resolved_at": resolved_at,
             }
             if "bug" in cases[case]:
-                bz_dict[case] = r_case.json()["bugzillas"]
+                bz_dict[case] = case_json["bugzillas"]
+
+            api_comments = case_json.get("comments", [])
+            if api_comments:
+                try:
+                    case_created_date = format_date(cases[case]["createdate"])
+                    load_comments_postgres(case, case_created_date, api_comments)
+                except Exception as e:
+                    logging.error("Failed to load comments for case %s: %s", case, e)
 
     libtelco5g.redis_set("details", json.dumps(case_details))
     libtelco5g.redis_set("case_bz", json.dumps(bz_dict))

--- a/dashboard/src/t5gweb/cache.py
+++ b/dashboard/src/t5gweb/cache.py
@@ -12,7 +12,11 @@ import requests
 from jira.exceptions import JIRAError
 
 from t5gweb import libtelco5g
-from t5gweb.database import load_cases_postgres, load_comments_postgres, load_jira_card_postgres
+from t5gweb.database import (
+    load_cases_postgres,
+    load_comments_postgres,
+    load_jira_card_postgres,
+)
 from t5gweb.utils import format_comment, format_date, make_headers
 
 

--- a/dashboard/src/t5gweb/database/__init__.py
+++ b/dashboard/src/t5gweb/database/__init__.py
@@ -11,7 +11,7 @@ This module provides database functionality including:
 from .models import Case, Comment, JiraCard, JiraComment
 
 # Import database operations
-from .operations import load_cases_postgres, load_jira_card_postgres
+from .operations import load_cases_postgres, load_comments_postgres, load_jira_card_postgres
 
 # Import session management components
 from .session import Base, create_postgres_tables, db_config
@@ -29,5 +29,6 @@ __all__ = [
     "JiraComment",
     # Operations
     "load_cases_postgres",
+    "load_comments_postgres",
     "load_jira_card_postgres",
 ]

--- a/dashboard/src/t5gweb/database/__init__.py
+++ b/dashboard/src/t5gweb/database/__init__.py
@@ -11,7 +11,11 @@ This module provides database functionality including:
 from .models import Case, Comment, JiraCard, JiraComment
 
 # Import database operations
-from .operations import load_cases_postgres, load_comments_postgres, load_jira_card_postgres
+from .operations import (
+    load_cases_postgres,
+    load_comments_postgres,
+    load_jira_card_postgres,
+)
 
 # Import session management components
 from .session import Base, create_postgres_tables, db_config

--- a/dashboard/src/t5gweb/database/models.py
+++ b/dashboard/src/t5gweb/database/models.py
@@ -1,10 +1,9 @@
 """SQLAlchemy database models"""
 
-from datetime import date, datetime
+from datetime import datetime
 from typing import List, Optional
 
 from sqlalchemy import (
-    Date,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -92,7 +91,7 @@ class Comment(Base):
 
     author: Mapped[str] = mapped_column(String, nullable=False)
     comment_text: Mapped[str] = mapped_column(Text, nullable=False)
-    commented_at: Mapped[date] = mapped_column(Date, nullable=False)
+    commented_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/dashboard/src/t5gweb/database/operations.py
+++ b/dashboard/src/t5gweb/database/operations.py
@@ -8,7 +8,7 @@ from dateutil import parser
 
 from t5gweb.utils import format_comment
 
-from .models import Case, JiraCard, JiraComment
+from .models import Case, Comment, JiraCard, JiraComment
 from .session import db_config
 
 
@@ -72,6 +72,70 @@ def load_cases_postgres(cases):
     finally:
         session.close()
         logging.warning("Loaded cases to Postgres")
+
+
+def load_comments_postgres(case_number, case_created_date, api_comments):
+    """Load or update Portal case comments in PostgreSQL.
+
+    Args:
+        case_number: The case number these comments belong to.
+        case_created_date: Parsed datetime of the case's creation date (for the
+            composite FK to the cases table).
+        api_comments: List of comment dicts from the Portal API, each containing
+            at minimum 'createdBy', 'commentBody', and 'createdDate'.
+    """
+    if not api_comments:
+        return
+
+    session = db_config.SessionLocal()
+    try:
+        existing_case = (
+            session.query(Case)
+            .filter_by(case_number=case_number, created_date=case_created_date)
+            .first()
+        )
+        if existing_case is None:
+            logging.warning(
+                "Cannot load comments for %s - case not found in database",
+                case_number,
+            )
+            return
+
+        for api_comment in api_comments:
+            comment_id = api_comment.get("id")
+            author = api_comment.get("createdBy", "unknown")
+            body = api_comment.get("commentBody", "")
+            commented_at_str = api_comment.get("createdDate")
+            if not commented_at_str:
+                continue
+
+            commented_at = parser.parse(commented_at_str)
+
+            existing = (
+                session.query(Comment)
+                .filter_by(
+                    case_number=case_number,
+                    author=author,
+                    commented_at=commented_at.date(),
+                )
+                .first()
+            )
+            if existing is None:
+                comment = Comment(
+                    case_number=case_number,
+                    created_date=case_created_date,
+                    author=author,
+                    comment_text=body,
+                    commented_at=commented_at.date(),
+                )
+                session.add(comment)
+
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        logging.error("Failed to load comments for case %s: %s", case_number, e)
+    finally:
+        session.close()
 
 
 def load_jira_card_postgres(cases, case_number, issue):

--- a/dashboard/src/t5gweb/database/operations.py
+++ b/dashboard/src/t5gweb/database/operations.py
@@ -102,7 +102,6 @@ def load_comments_postgres(case_number, case_created_date, api_comments):
             return
 
         for api_comment in api_comments:
-            comment_id = api_comment.get("id")
             author = api_comment.get("createdBy", "unknown")
             body = api_comment.get("commentBody", "")
             commented_at_str = api_comment.get("createdDate")

--- a/dashboard/src/t5gweb/database/operations.py
+++ b/dashboard/src/t5gweb/database/operations.py
@@ -115,7 +115,7 @@ def load_comments_postgres(case_number, case_created_date, api_comments):
                 .filter_by(
                     case_number=case_number,
                     author=author,
-                    commented_at=commented_at.date(),
+                    commented_at=commented_at,
                 )
                 .first()
             )
@@ -125,7 +125,7 @@ def load_comments_postgres(case_number, case_created_date, api_comments):
                     created_date=case_created_date,
                     author=author,
                     comment_text=body,
-                    commented_at=commented_at.date(),
+                    commented_at=commented_at,
                 )
                 session.add(comment)
 

--- a/dashboard/src/tests/test_database.py
+++ b/dashboard/src/tests/test_database.py
@@ -13,9 +13,11 @@ import pytest
 from dateutil import parser
 from t5gweb.database import (
     Case,
+    Comment,
     JiraCard,
     JiraComment,
     load_cases_postgres,
+    load_comments_postgres,
     load_jira_card_postgres,
 )
 
@@ -335,6 +337,119 @@ class TestDatabaseOperations:
             test_db_session.query(JiraComment).filter_by(jira_card_id="TEST-123").all()
         )
         assert len(comments) == 2
+
+
+class TestLoadCommentsPostgres:
+    """Test load_comments_postgres operation"""
+
+    def test_load_comments_creates_records(self, test_db_session):
+        case_data = create_test_case_data()
+        load_cases_postgres(case_data)
+
+        api_comments = [
+            {
+                "id": "abc1",
+                "createdBy": "engineer1",
+                "commentBody": "First comment",
+                "createdDate": "2024-01-01T10:00:00Z",
+            },
+            {
+                "id": "abc2",
+                "createdBy": "engineer2",
+                "commentBody": "Second comment",
+                "createdDate": "2024-01-02T14:30:00Z",
+            },
+        ]
+
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+        load_comments_postgres("12345678", case_created_date, api_comments)
+
+        comments = test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        assert len(comments) == 2
+        assert {c.author for c in comments} == {"engineer1", "engineer2"}
+
+    def test_load_comments_skips_duplicates(self, test_db_session):
+        case_data = create_test_case_data()
+        load_cases_postgres(case_data)
+
+        api_comments = [
+            {
+                "id": "abc1",
+                "createdBy": "engineer1",
+                "commentBody": "Same comment",
+                "createdDate": "2024-01-01T10:00:00Z",
+            },
+        ]
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+
+        load_comments_postgres("12345678", case_created_date, api_comments)
+        load_comments_postgres("12345678", case_created_date, api_comments)
+
+        comments = test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        assert len(comments) == 1
+
+    def test_load_comments_skips_missing_case(self, test_db_session):
+        api_comments = [
+            {
+                "id": "abc1",
+                "createdBy": "engineer1",
+                "commentBody": "Orphan comment",
+                "createdDate": "2024-01-01T10:00:00Z",
+            },
+        ]
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+
+        load_comments_postgres("99999999", case_created_date, api_comments)
+
+        comments = test_db_session.query(Comment).all()
+        assert len(comments) == 0
+
+    def test_load_comments_skips_empty_list(self, test_db_session):
+        case_data = create_test_case_data()
+        load_cases_postgres(case_data)
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+
+        load_comments_postgres("12345678", case_created_date, [])
+
+        comments = test_db_session.query(Comment).all()
+        assert len(comments) == 0
+
+    def test_load_comments_skips_missing_date(self, test_db_session):
+        case_data = create_test_case_data()
+        load_cases_postgres(case_data)
+
+        api_comments = [
+            {
+                "id": "abc1",
+                "createdBy": "engineer1",
+                "commentBody": "No date comment",
+            },
+        ]
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+
+        load_comments_postgres("12345678", case_created_date, api_comments)
+
+        comments = test_db_session.query(Comment).all()
+        assert len(comments) == 0
+
+    def test_load_comments_relationship_to_case(self, test_db_session):
+        case_data = create_test_case_data()
+        load_cases_postgres(case_data)
+
+        api_comments = [
+            {
+                "id": "abc1",
+                "createdBy": "engineer1",
+                "commentBody": "Related comment",
+                "createdDate": "2024-01-01T10:00:00Z",
+            },
+        ]
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+        load_comments_postgres("12345678", case_created_date, api_comments)
+
+        case = test_db_session.query(Case).filter_by(case_number="12345678").first()
+        assert len(case.comments) == 1
+        assert case.comments[0].author == "engineer1"
 
 
 class TestDataIntegrity:

--- a/dashboard/src/tests/test_database.py
+++ b/dashboard/src/tests/test_database.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from dateutil import parser
+
 from t5gweb.database import (
     Case,
     Comment,
@@ -364,7 +365,9 @@ class TestLoadCommentsPostgres:
         case_created_date = parser.parse("2024-01-01T00:00:00Z")
         load_comments_postgres("12345678", case_created_date, api_comments)
 
-        comments = test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        comments = (
+            test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        )
         assert len(comments) == 2
         assert {c.author for c in comments} == {"engineer1", "engineer2"}
 
@@ -385,7 +388,9 @@ class TestLoadCommentsPostgres:
         load_comments_postgres("12345678", case_created_date, api_comments)
         load_comments_postgres("12345678", case_created_date, api_comments)
 
-        comments = test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        comments = (
+            test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        )
         assert len(comments) == 1
 
     def test_load_comments_skips_missing_case(self, test_db_session):

--- a/dashboard/src/tests/test_database.py
+++ b/dashboard/src/tests/test_database.py
@@ -393,6 +393,36 @@ class TestLoadCommentsPostgres:
         )
         assert len(comments) == 1
 
+    def test_load_comments_same_author_same_day_different_times(self, test_db_session):
+        case_data = create_test_case_data()
+        load_cases_postgres(case_data)
+
+        api_comments = [
+            {
+                "id": "abc1",
+                "createdBy": "engineer1",
+                "commentBody": "Morning comment",
+                "createdDate": "2024-01-01T09:00:00Z",
+            },
+            {
+                "id": "abc2",
+                "createdBy": "engineer1",
+                "commentBody": "Afternoon comment",
+                "createdDate": "2024-01-01T15:30:00Z",
+            },
+        ]
+        case_created_date = parser.parse("2024-01-01T00:00:00Z")
+        load_comments_postgres("12345678", case_created_date, api_comments)
+
+        comments = (
+            test_db_session.query(Comment).filter_by(case_number="12345678").all()
+        )
+        assert len(comments) == 2
+        assert {c.comment_text for c in comments} == {
+            "Morning comment",
+            "Afternoon comment",
+        }
+
     def test_load_comments_skips_missing_case(self, test_db_session):
         api_comments = [
             {


### PR DESCRIPTION
This PR extends the PostgreSQL data persistence layer to store case comments from the Red Hat Portal API alongside existing case and JIRA card data.

  Key Changes:
  - New function load_comments_postgres() in database/operations.py to insert Portal API comments into the comments table
  - Integration with case details cache: Modified cache.py:get_case_details() to extract comments from Portal API responses and persist them via load_comments_postgres()
  - Updated database module exports to include the new load_comments_postgres function
  - Error handling: Wrapped comment loading in try-except to prevent failures from breaking case detail fetching

  Implementation Details:
  - Comments are linked to cases via composite foreign key (case_number, created_date)
  - Deduplication logic: existing comments are identified by case_number, author, and commented_at date
  - Only new comments are inserted; duplicates are skipped
  - Stores: author, comment text, and comment date (extracted from Portal API's createdBy, commentBody, createdDate fields)

 Testing Recommendations
  - Verify comments are being stored for cases with existing Portal API comments
  - Confirm that duplicate comments are not inserted on subsequent cache refreshes
  - Check that cases without comments do not cause errors

Co-Authored-By: Claude Opus 4.6 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)