### PR TITLE
WIP: Add AI agent integration for case analysis

### DIFF
--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - FLASK_LOGIN_DISABLED=true # Disable SSO Login for dev environments
+      - FLASK_LOGIN_DISABLED=true  # Disable SSO Login for dev environments
       - FLASK_DEBUG=true
       - AI_AGENTS_API_URL=http://ai-agents:8081
     depends_on:

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - redis_data:/data
   ### PostgresQL
   postgresql:
-    image: docker.io/postgres:latest
+    image: pgvector/pgvector:pg17
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=secret
@@ -40,6 +40,7 @@ services:
     environment:
       - FLASK_LOGIN_DISABLED=true # Disable SSO Login for dev environments
       - FLASK_DEBUG=true
+      - AI_AGENTS_API_URL=http://ai-agents:8081
     depends_on:
       redis:
         condition: service_healthy

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 
 import requests as http_requests
 from flask import Blueprint, jsonify, request
@@ -175,15 +176,27 @@ def _ai_proxy(method, path, **kwargs):
         return jsonify({"error": "AI Agents service timeout"}), 504
 
 
+def _validate_case_number(case_number):
+    if not re.fullmatch(r"[0-9]{8}", case_number):
+        return jsonify({"error": "Case number must be exactly 8 digits"}), 400
+    return None
+
+
 @BP.route("/ai/report/case/<string:case_number>")
 @login_required
 def ai_report_by_case(case_number):
+    err = _validate_case_number(case_number)
+    if err:
+        return err
     return _ai_proxy("get", f"/report/case/{case_number}")
 
 
 @BP.route("/ai/analyze/<string:case_number>", methods=["POST"])
 @login_required
 def ai_analyze(case_number):
+    err = _validate_case_number(case_number)
+    if err:
+        return err
     force = request.args.get("force", "false").lower() == "true"
     return _ai_proxy("post", f"/analyze/{case_number}", params={"force": force})
 

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -1,7 +1,10 @@
 """API endpoints for t5gweb"""
 
 import json
+import logging
+import os
 
+import requests as http_requests
 from flask import Blueprint, jsonify, request
 from flask_login import login_required
 from t5gweb.cache import (
@@ -15,6 +18,8 @@ from t5gweb.cache import (
 )
 from t5gweb.libtelco5g import generate_stats, redis_get, redis_set, sync_portal_to_jira
 from t5gweb.utils import set_cfg
+
+log = logging.getLogger(__name__)
 
 BP = Blueprint("api", __name__, url_prefix="/api")
 
@@ -151,3 +156,52 @@ def show_stats():
     """Generate and return current statistics in JSON format."""
     stats = generate_stats()
     return jsonify(stats)
+
+
+def _ai_api_url():
+    return os.environ.get("AI_AGENTS_API_URL", "http://localhost:8081")
+
+
+def _ai_proxy(method, path, **kwargs):
+    url = f"{_ai_api_url()}{path}"
+    try:
+        resp = getattr(http_requests, method)(url, timeout=30, **kwargs)
+        return jsonify(resp.json()), resp.status_code
+    except http_requests.ConnectionError:
+        log.warning("AI Agents API unreachable at %s", url)
+        return jsonify({"error": "AI Agents service unavailable"}), 502
+    except http_requests.Timeout:
+        return jsonify({"error": "AI Agents service timeout"}), 504
+
+
+@BP.route("/ai/report/case/<string:case_number>")
+@login_required
+def ai_report_by_case(case_number):
+    return _ai_proxy("get", f"/report/case/{case_number}")
+
+
+@BP.route("/ai/analyze/<string:case_number>", methods=["POST"])
+@login_required
+def ai_analyze(case_number):
+    force = request.args.get("force", "false").lower() == "true"
+    return _ai_proxy("post", f"/analyze/{case_number}", params={"force": force})
+
+
+@BP.route("/ai/status/<string:task_id>")
+@login_required
+def ai_status(task_id):
+    return _ai_proxy("get", f"/status/{task_id}")
+
+
+@BP.route("/ai/logs/<string:analysis_id>")
+@login_required
+def ai_logs(analysis_id):
+    return _ai_proxy("get", f"/logs/{analysis_id}")
+
+
+@BP.route("/ai/feedback/<string:analysis_id>", methods=["GET", "POST"])
+@login_required
+def ai_feedback(analysis_id):
+    if request.method == "POST":
+        return _ai_proxy("post", f"/feedback/{analysis_id}", json=request.get_json())
+    return _ai_proxy("get", f"/feedback/{analysis_id}")

--- a/dashboard/src/t5gweb/api.py
+++ b/dashboard/src/t5gweb/api.py
@@ -7,6 +7,7 @@ import os
 import requests as http_requests
 from flask import Blueprint, jsonify, request
 from flask_login import login_required
+
 from t5gweb.cache import (
     get_bz_details,
     get_cards,

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -3,6 +3,8 @@
 var currentAnalysisId = null
 var currentCaseNumber = null
 var showingRaw = false
+var pollErrorCount = 0
+var MAX_POLL_ERRORS = 5
 
 $(document).ready(function () {
   $('#search-btn').click(searchCase)
@@ -258,6 +260,7 @@ function toggleView () {
 function triggerAnalysis (force) {
   if (!currentCaseNumber) return
   hideAlert()
+  pollErrorCount = 0
   $('#no-report').addClass('d-none')
   $('#report-container').addClass('d-none')
   $('#analysis-progress').removeClass('d-none')
@@ -299,6 +302,7 @@ function pollStatus (taskId) {
     method: 'GET',
     dataType: 'json',
     success: function (data) {
+      pollErrorCount = 0
       var statusText = 'State: ' + data.state
       if (data.state === 'PENDING') {
         statusText = 'Queued, waiting for worker...'
@@ -308,11 +312,11 @@ function pollStatus (taskId) {
       $('#analysis-status-text').text(statusText)
 
       if (data.state === 'SUCCESS') {
-        sessionStorage.removeItem('activeAnalysis') // Clear on success
+        sessionStorage.removeItem('activeAnalysis')
         $('#analysis-progress').addClass('d-none')
         searchCase()
       } else if (data.state === 'FAILURE') {
-        sessionStorage.removeItem('activeAnalysis') // Clear on failure
+        sessionStorage.removeItem('activeAnalysis')
         $('#analysis-progress').addClass('d-none')
         showAlert('Analysis failed: ' + (data.error || 'Unknown error'), 'danger')
       } else {
@@ -320,12 +324,14 @@ function pollStatus (taskId) {
       }
     },
     error: function (xhr) {
-      // If task not found (404), clear storage - task expired
-      if (xhr.status === 404) {
+      pollErrorCount++
+      if (pollErrorCount >= MAX_POLL_ERRORS) {
+        pollErrorCount = 0
         sessionStorage.removeItem('activeAnalysis')
         $('#analysis-progress').addClass('d-none')
-        showAlert('Analysis task expired. Please run a new analysis.', 'warning')
+        showAlert('Lost contact with analysis task after multiple retries. Please run a new analysis.', 'warning')
       } else {
+        $('#analysis-status-text').text('Connection issue, retrying... (' + pollErrorCount + '/' + MAX_POLL_ERRORS + ')')
         setTimeout(function () { pollStatus(taskId) }, 5000)
       }
     }

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -1,10 +1,10 @@
-/* global $, bootstrap */
+/* global $ */
 
-var currentAnalysisId = null
-var currentCaseNumber = null
-var showingRaw = false
-var pollErrorCount = 0
-var MAX_POLL_ERRORS = 5
+let currentAnalysisId = null
+let currentCaseNumber = null
+let showingRaw = false
+let pollErrorCount = 0
+const MAX_POLL_ERRORS = 5
 
 $(document).ready(function () {
   $('#search-btn').click(searchCase)
@@ -33,7 +33,7 @@ function hideAlert () {
 }
 
 function searchCase () {
-  var caseNum = $('#case-number-input').val().trim()
+  const caseNum = $('#case-number-input').val().trim()
   if (!caseNum) return
   currentCaseNumber = caseNum
   hideAlert()
@@ -63,18 +63,18 @@ function searchCase () {
 
 function renderReport (data) {
   currentAnalysisId = data.id
-  var report = data.full_report || {}
+  const report = data.full_report || {}
 
-  var statusBadge = $('#report-status-badge')
+  const statusBadge = $('#report-status-badge')
   statusBadge.text(data.status || 'unknown')
   statusBadge.attr('class', 'badge ' + statusBadgeClass(data.status))
 
-  var confidence = (report.analysis || {}).confidence || 'unknown'
-  var confBadge = $('#report-confidence-badge')
+  const confidence = (report.analysis || {}).confidence || 'unknown'
+  const confBadge = $('#report-confidence-badge')
   confBadge.text('Confidence: ' + confidence)
   confBadge.attr('class', 'badge ' + confidenceBadgeClass(confidence))
 
-  var meta = 'Case ' + data.case_number
+  let meta = 'Case ' + data.case_number
   if (data.timestamp) meta += ' | ' + new Date(data.timestamp).toLocaleString()
   if (data.model_id) meta += ' | ' + data.model_id
   if (data.rounds_executed) meta += ' | ' + data.rounds_executed + ' round(s)'
@@ -113,23 +113,23 @@ function renderReport (data) {
 }
 
 function renderDomainTags (report) {
-  var tags = ((report.analysis || {}).domain_tags || [])
+  const tags = ((report.analysis || {}).domain_tags || [])
   if (tags.length === 0) {
     $('#domain-tags-card').addClass('d-none')
     return
   }
   $('#domain-tags-card').removeClass('d-none')
-  var html = tags.map(function (t) {
+  const html = tags.map(function (t) {
     return '<span class="badge bg-secondary me-1">' + escapeHtml(t) + '</span>'
   }).join('')
   $('#domain-tags-body').html(html)
 }
 
 function renderRecommendations (report) {
-  var recs = report.recommendations || []
+  const recs = report.recommendations || []
   if (recs.length === 0) { $('#recommendations-card').addClass('d-none'); return }
   $('#recommendations-card').removeClass('d-none')
-  var html = recs.map(function (r) {
+  const html = recs.map(function (r) {
     return '<tr><td>' + markdownToHtml(r.action) + '</td>' +
       '<td><code>' + escapeHtml(r.command || '') + '</code></td>' +
       '<td><span class="badge ' + riskBadgeClass(r.risk) + '">' + escapeHtml(r.risk || 'safe') + '</span></td></tr>'
@@ -138,11 +138,11 @@ function renderRecommendations (report) {
 }
 
 function renderSimilarCases (report) {
-  var cases = report.similar_cases || []
+  const cases = report.similar_cases || []
   if (cases.length === 0) { $('#similar-cases-card').addClass('d-none'); return }
   $('#similar-cases-card').removeClass('d-none')
-  var html = cases.map(function (c) {
-    var caseLink = '<a href="https://access.redhat.com/support/cases/' + escapeHtml(c.case_number) + '" target="_blank">' + escapeHtml(c.case_number) + '</a>'
+  const html = cases.map(function (c) {
+    const caseLink = '<a href="https://access.redhat.com/support/cases/' + escapeHtml(c.case_number) + '" target="_blank">' + escapeHtml(c.case_number) + '</a>'
     return '<tr><td>' + caseLink + '</td>' +
       '<td>' + (c.similarity ? (c.similarity * 100).toFixed(0) + '%' : '') + '</td>' +
       '<td><span class="badge ' + relevanceBadgeClass(c.relevance) + '">' + escapeHtml(c.relevance || '') + '</span></td>' +
@@ -152,11 +152,11 @@ function renderSimilarCases (report) {
 }
 
 function renderJiras (report) {
-  var jiras = report.engineering_jiras || []
+  const jiras = report.engineering_jiras || []
   if (jiras.length === 0) { $('#jiras-card').addClass('d-none'); return }
   $('#jiras-card').removeClass('d-none')
-  var html = jiras.map(function (j) {
-    var keyHtml = j.url
+  const html = jiras.map(function (j) {
+    const keyHtml = j.url
       ? '<a href="' + escapeHtml(j.url) + '" target="_blank">' + escapeHtml(j.key) + '</a>'
       : escapeHtml(j.key)
     return '<tr><td>' + keyHtml + '</td>' +
@@ -169,11 +169,11 @@ function renderJiras (report) {
 }
 
 function renderKB (report) {
-  var refs = report.kb_references || []
+  const refs = report.kb_references || []
   if (refs.length === 0) { $('#kb-card').addClass('d-none'); return }
   $('#kb-card').removeClass('d-none')
-  var html = refs.map(function (r) {
-    var titleHtml = r.url
+  const html = refs.map(function (r) {
+    const titleHtml = r.url
       ? '<a href="' + escapeHtml(r.url) + '" target="_blank">' + escapeHtml(r.title) + '</a>'
       : escapeHtml(r.title)
     return '<tr><td>' + titleHtml + '</td>' +
@@ -184,25 +184,25 @@ function renderKB (report) {
 }
 
 function renderQuestions (report) {
-  var qs = report.clarifying_questions || []
+  const qs = report.clarifying_questions || []
   if (qs.length === 0) { $('#questions-card').addClass('d-none'); return }
   $('#questions-card').removeClass('d-none')
-  var html = qs.map(function (q) { return '<li>' + escapeHtml(q) + '</li>' }).join('')
+  const html = qs.map(function (q) { return '<li>' + escapeHtml(q) + '</li>' }).join('')
   $('#questions-list').html(html)
 }
 
 function renderAgentSummaries (report) {
-  var summaries = report.agent_summaries || {}
-  var agents = report.agents_consulted || []
+  const summaries = report.agent_summaries || {}
+  const agents = report.agents_consulted || []
   if (agents.length === 0 && Object.keys(summaries).length === 0) {
     $('#agents-card').addClass('d-none')
     return
   }
   $('#agents-card').removeClass('d-none')
-  var html = ''
-  var keys = Object.keys(summaries).length > 0 ? Object.keys(summaries) : agents
+  let html = ''
+  const keys = Object.keys(summaries).length > 0 ? Object.keys(summaries) : agents
   keys.forEach(function (name) {
-    var s = summaries[name] || {}
+    const s = summaries[name] || {}
     html += '<div class="mb-2"><strong>' + escapeHtml(name) + '</strong>'
     if (s.status) html += ' <span class="badge bg-secondary">' + escapeHtml(s.status) + '</span>'
     if (s.confidence) html += ' <span class="badge bg-info">' + (s.confidence * 100).toFixed(0) + '%</span>'
@@ -213,10 +213,10 @@ function renderAgentSummaries (report) {
 }
 
 function renderDegraded (report) {
-  var steps = report.degraded_steps || []
+  const steps = report.degraded_steps || []
   if (steps.length === 0) { $('#degraded-card').addClass('d-none'); return }
   $('#degraded-card').removeClass('d-none')
-  var html = steps.map(function (d) {
+  const html = steps.map(function (d) {
     return '<tr><td>' + escapeHtml(d.step) + '</td>' +
       '<td>' + escapeHtml(d.reason) + '</td>' +
       '<td>' + escapeHtml(d.impact) + '</td></tr>'
@@ -225,18 +225,18 @@ function renderDegraded (report) {
 }
 
 function renderWarnings (report) {
-  var warns = report.context_warnings || []
+  const warns = report.context_warnings || []
   if (warns.length === 0) { $('#warnings-card').addClass('d-none'); return }
   $('#warnings-card').removeClass('d-none')
-  var html = warns.map(function (w) { return '<li>' + escapeHtml(w) + '</li>' }).join('')
+  const html = warns.map(function (w) { return '<li>' + escapeHtml(w) + '</li>' }).join('')
   $('#warnings-list').html(html)
 }
 
 function renderAttachments (report) {
-  var atts = report.attachments_reviewed || []
+  const atts = report.attachments_reviewed || []
   if (atts.length === 0) { $('#attachments-card').addClass('d-none'); return }
   $('#attachments-card').removeClass('d-none')
-  var html = atts.map(function (a) {
+  const html = atts.map(function (a) {
     return '<tr><td>' + escapeHtml(a.file_name) + '</td>' +
       '<td>' + escapeHtml(a.file_type || '') + '</td>' +
       '<td>' + (a.size_kb || '') + '</td>' +
@@ -246,8 +246,8 @@ function renderAttachments (report) {
 }
 
 function renderValidation (mgValidation, sosValidation) {
-  var mgActive = mgValidation && mgValidation.validated
-  var sosActive = sosValidation && sosValidation.validated
+  const mgActive = mgValidation && mgValidation.validated
+  const sosActive = sosValidation && sosValidation.validated
 
   if (!mgActive && !sosActive) {
     $('#validation-card').addClass('d-none')
@@ -255,13 +255,13 @@ function renderValidation (mgValidation, sosValidation) {
   }
   $('#validation-card').removeClass('d-none')
 
-  var primary = mgActive ? mgValidation : sosValidation
-  var decisionClass = 'bg-secondary'
+  const primary = mgActive ? mgValidation : sosValidation
+  let decisionClass = 'bg-secondary'
   if (primary.decision === 'confirmed') decisionClass = 'bg-success'
   else if (primary.decision === 'refuted') decisionClass = 'bg-danger'
   else if (primary.decision === 'inconclusive') decisionClass = 'bg-warning text-dark'
 
-  var html = '<div class="mb-3">'
+  let html = '<div class="mb-3">'
   html += '<span class="badge ' + decisionClass + ' me-2">' + escapeHtml(primary.decision) + '</span>'
   if (primary.confidence != null) {
     html += '<span class="badge bg-info me-2">Confidence: ' + (primary.confidence * 100).toFixed(0) + '%</span>'
@@ -275,10 +275,10 @@ function renderValidation (mgValidation, sosValidation) {
     html += '<p>' + markdownToHtml(primary.reasoning) + '</p>'
   }
 
-  var cmdIndex = 0
+  let cmdIndex = 0
 
   if (mgActive) {
-    var mgCmds = mgValidation.commands_executed || []
+    const mgCmds = mgValidation.commands_executed || []
     if (mgCmds.length > 0) {
       html += '<h6 class="mt-3">Must-Gather Commands'
       if (mgValidation.filename) {
@@ -293,7 +293,7 @@ function renderValidation (mgValidation, sosValidation) {
   }
 
   if (sosActive) {
-    var sosCmds = sosValidation.commands_executed || []
+    const sosCmds = sosValidation.commands_executed || []
     if (sosCmds.length > 0) {
       html += '<h6 class="mt-3">Sos-Report Commands'
       if (sosValidation.filename) {
@@ -310,17 +310,17 @@ function renderValidation (mgValidation, sosValidation) {
 }
 
 function _renderCommandAccordion (cmds, prefix, startIdx) {
-  var html = '<div class="accordion mb-2" id="val-' + prefix + '-accordion">'
+  let html = '<div class="accordion mb-2" id="val-' + prefix + '-accordion">'
   cmds.forEach(function (cmd, idx) {
-    var statusIcon = '?'
-    var statusClass = 'text-secondary'
+    let statusIcon = '?'
+    let statusClass = 'text-secondary'
     if (cmd.status === 'success') { statusIcon = '✓'; statusClass = 'text-success' }
     else if (cmd.status === 'empty') { statusIcon = '○'; statusClass = 'text-muted' }
     else if (cmd.status === 'timeout') { statusIcon = '⏱'; statusClass = 'text-warning' }
     else if (cmd.status === 'error' || cmd.status === 'omc_error') { statusIcon = '✗'; statusClass = 'text-danger' }
 
-    var cmdText = cmd.command || cmd.original_command || 'N/A'
-    var collapseId = 'val-' + prefix + '-cmd-' + (startIdx + idx)
+    const cmdText = cmd.command || cmd.original_command || 'N/A'
+    const collapseId = 'val-' + prefix + '-cmd-' + (startIdx + idx)
 
     html += '<div class="accordion-item">'
     html += '<h2 class="accordion-header">'
@@ -367,11 +367,11 @@ function triggerAnalysis (force) {
   $('#analysis-progress').removeClass('d-none')
   $('#analysis-status-text').text('Queuing analysis...')
 
-  var url = '/api/ai/analyze/' + encodeURIComponent(currentCaseNumber)
+  let url = '/api/ai/analyze/' + encodeURIComponent(currentCaseNumber)
   if (force) url += '?force=true'
 
   $.ajax({
-    url: url,
+    url,
     method: 'POST',
     dataType: 'json',
     success: function (data) {
@@ -404,7 +404,7 @@ function pollStatus (taskId) {
     dataType: 'json',
     success: function (data) {
       pollErrorCount = 0
-      var statusText = 'State: ' + data.state
+      let statusText = 'State: ' + data.state
       if (data.state === 'PENDING') {
         statusText = 'Queued, waiting for worker...'
       } else if (data.state === 'STARTED') {
@@ -424,7 +424,7 @@ function pollStatus (taskId) {
         setTimeout(function () { pollStatus(taskId) }, 3000)
       }
     },
-    error: function (xhr) {
+    error: function () {
       pollErrorCount++
       if (pollErrorCount >= MAX_POLL_ERRORS) {
         pollErrorCount = 0
@@ -452,12 +452,12 @@ function loadThinkingLog () {
         $('#thinking-log-tbody').html('<tr><td colspan="7" class="text-muted text-center">No log entries</td></tr>')
         return
       }
-      var html = logs.map(function (l) {
-        var round = l.round !== undefined ? l.round : (l.step_number !== undefined ? l.step_number : '')
-        var tokensIn = l.input_tokens != null ? formatNumber(l.input_tokens) : ''
-        var tokensOut = l.output_tokens != null ? formatNumber(l.output_tokens) : ''
-        var tokensInClass = l.input_tokens != null ? '' : 'text-muted'
-        var tokensOutClass = l.output_tokens != null ? '' : 'text-muted'
+      const html = logs.map(function (l) {
+        const round = l.round !== undefined ? l.round : (l.step_number !== undefined ? l.step_number : '')
+        const tokensIn = l.input_tokens != null ? formatNumber(l.input_tokens) : ''
+        const tokensOut = l.output_tokens != null ? formatNumber(l.output_tokens) : ''
+        const tokensInClass = l.input_tokens != null ? '' : 'text-muted'
+        const tokensOutClass = l.output_tokens != null ? '' : 'text-muted'
 
         return '<tr><td>' + round + '</td>' +
           '<td>' + escapeHtml(l.agent_name || '') + '</td>' +
@@ -487,7 +487,7 @@ function submitFeedback (vote) {
     url: '/api/ai/feedback/' + encodeURIComponent(currentAnalysisId),
     method: 'POST',
     contentType: 'application/json',
-    data: JSON.stringify({ vote: vote }),
+    data: JSON.stringify({ vote }),
     dataType: 'json',
     success: function () {
       $('#feedback-status').text('Feedback submitted!')
@@ -506,12 +506,12 @@ function submitFeedback (vote) {
 }
 
 function resumeOngoingAnalysis () {
-  var stored = sessionStorage.getItem('activeAnalysis')
+  const stored = sessionStorage.getItem('activeAnalysis')
   if (!stored) return
 
   try {
-    var data = JSON.parse(stored)
-    var ageHours = (Date.now() - data.started_at) / (1000 * 60 * 60)
+    const data = JSON.parse(stored)
+    const ageHours = (Date.now() - data.started_at) / (1000 * 60 * 60)
 
     // Ignore if older than 2 hours (likely expired)
     if (ageHours > 2) {
@@ -565,7 +565,7 @@ function relevanceBadgeClass (relevance) {
 
 function escapeHtml (str) {
   if (!str) return ''
-  var div = document.createElement('div')
+  const div = document.createElement('div')
   div.appendChild(document.createTextNode(str))
   return div.innerHTML
 }
@@ -574,7 +574,7 @@ function markdownToHtml (markdown) {
   if (!markdown) return ''
 
   // Escape HTML first
-  var html = escapeHtml(markdown)
+  let html = escapeHtml(markdown)
 
   // Convert markdown to HTML
   // Bold **text**

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -35,6 +35,10 @@ function hideAlert () {
 function searchCase () {
   const caseNum = $('#case-number-input').val().trim()
   if (!caseNum) return
+  if (!/^[0-9]{8}$/.test(caseNum)) {
+    showAlert('Case number must be exactly 8 digits (e.g. 03252981)', 'warning')
+    return
+  }
   currentCaseNumber = caseNum
   hideAlert()
   $('#report-container').addClass('d-none')

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -307,7 +307,7 @@ function pollStatus (taskId) {
       if (data.state === 'PENDING') {
         statusText = 'Queued, waiting for worker...'
       } else if (data.state === 'STARTED') {
-        statusText = 'Running AI analysis (this takes 2-4 minutes)...'
+        statusText = 'Running AI analysis...'
       }
       $('#analysis-status-text').text(statusText)
 

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -92,6 +92,8 @@ function renderReport (data) {
   renderDegraded(report)
   renderWarnings(report)
   renderAttachments(report)
+  renderMgValidation(data.must_gather_validation)
+  renderSosValidation(data.sos_report_validation)
 
   $('#raw-json').text(JSON.stringify(data, null, 2))
 
@@ -242,6 +244,85 @@ function renderAttachments (report) {
       '<td>' + escapeHtml(a.status || '') + '</td></tr>'
   }).join('')
   $('#attachments-tbody').html(html)
+}
+
+function renderValidationCard (validation, cardId, bodyId, cmdLabel) {
+  if (!validation || !validation.validated) {
+    $(cardId).addClass('d-none')
+    return
+  }
+  $(cardId).removeClass('d-none')
+
+  var decisionClass = 'bg-secondary'
+  if (validation.decision === 'confirmed') decisionClass = 'bg-success'
+  else if (validation.decision === 'refuted') decisionClass = 'bg-danger'
+  else if (validation.decision === 'inconclusive') decisionClass = 'bg-warning text-dark'
+
+  var html = '<div class="mb-3">'
+  html += '<span class="badge ' + decisionClass + ' me-2">' + escapeHtml(validation.decision) + '</span>'
+  if (validation.confidence != null) {
+    html += '<span class="badge bg-info me-2">Confidence: ' + (validation.confidence * 100).toFixed(0) + '%</span>'
+  }
+  if (validation.round) {
+    html += '<span class="badge bg-secondary">Round ' + validation.round + '</span>'
+  }
+  html += '</div>'
+
+  if (validation.reasoning) {
+    html += '<p>' + markdownToHtml(validation.reasoning) + '</p>'
+  }
+
+  if (validation.filename) {
+    html += '<p class="text-muted mb-2"><small>Archive: ' + escapeHtml(validation.filename)
+    if (validation.size_mb) html += ' (' + validation.size_mb.toFixed(1) + ' MB)'
+    html += '</small></p>'
+  }
+
+  var cmds = validation.commands_executed || []
+  if (cmds.length > 0) {
+    html += '<div class="accordion" id="' + bodyId + '-accordion">'
+    cmds.forEach(function (cmd, idx) {
+      var statusIcon = '?'
+      var statusClass = 'text-secondary'
+      if (cmd.status === 'success') { statusIcon = '✓'; statusClass = 'text-success' }
+      else if (cmd.status === 'empty') { statusIcon = '○'; statusClass = 'text-muted' }
+      else if (cmd.status === 'timeout') { statusIcon = '⏱'; statusClass = 'text-warning' }
+      else if (cmd.status === 'error' || cmd.status === 'omc_error') { statusIcon = '✗'; statusClass = 'text-danger' }
+
+      var cmdText = cmd.command || cmd.original_command || 'N/A'
+      var collapseId = bodyId + '-cmd-' + idx
+
+      html += '<div class="accordion-item">'
+      html += '<h2 class="accordion-header">'
+      html += '<button class="accordion-button collapsed py-2" type="button" data-bs-toggle="collapse" data-bs-target="#' + collapseId + '">'
+      html += '<span class="' + statusClass + ' me-2">' + statusIcon + '</span> '
+      html += '<code class="me-2">' + escapeHtml(cmdText) + '</code> '
+      if (cmd.duration_ms) html += '<small class="text-muted">' + cmd.duration_ms + 'ms</small>'
+      html += '</button></h2>'
+      html += '<div id="' + collapseId + '" class="accordion-collapse collapse">'
+      html += '<div class="accordion-body">'
+      if (cmd.stdout) {
+        html += '<pre class="bg-light p-2 border rounded" style="max-height:300px;overflow:auto;font-size:0.85em">' + escapeHtml(cmd.stdout) + '</pre>'
+      } else {
+        html += '<p class="text-muted">(no output)</p>'
+      }
+      if (cmd.stderr) {
+        html += '<pre class="bg-light p-2 border rounded text-danger" style="max-height:150px;overflow:auto;font-size:0.85em">' + escapeHtml(cmd.stderr) + '</pre>'
+      }
+      html += '</div></div></div>'
+    })
+    html += '</div>'
+  }
+
+  $(bodyId).html(html)
+}
+
+function renderMgValidation (validation) {
+  renderValidationCard(validation, '#mg-validation-card', '#mg-validation-body', 'OMC')
+}
+
+function renderSosValidation (validation) {
+  renderValidationCard(validation, '#sos-validation-card', '#sos-validation-body', 'Command')
 }
 
 function toggleView () {

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -1,0 +1,396 @@
+/* global $, bootstrap */
+
+var currentAnalysisId = null
+var currentCaseNumber = null
+var showingRaw = false
+
+$(document).ready(function () {
+  $('#search-btn').click(searchCase)
+  $('#case-number-input').keypress(function (e) {
+    if (e.which === 13) searchCase()
+  })
+  $('#toggle-view-btn').click(toggleView)
+  $('#reanalyze-btn').click(function () { triggerAnalysis(true) })
+  $('#run-analysis-btn').click(function () { triggerAnalysis(false) })
+  $('#feedback-up').click(function () { submitFeedback('up') })
+  $('#feedback-down').click(function () { submitFeedback('down') })
+})
+
+function showAlert (msg, type) {
+  $('#agent-alert')
+    .removeClass('d-none alert-danger alert-warning alert-info alert-success')
+    .addClass('alert-' + type)
+    .text(msg)
+}
+
+function hideAlert () {
+  $('#agent-alert').addClass('d-none')
+}
+
+function searchCase () {
+  var caseNum = $('#case-number-input').val().trim()
+  if (!caseNum) return
+  currentCaseNumber = caseNum
+  hideAlert()
+  $('#report-container').addClass('d-none')
+  $('#no-report').addClass('d-none')
+  $('#analysis-progress').addClass('d-none')
+
+  $.ajax({
+    url: '/api/ai/report/case/' + encodeURIComponent(caseNum),
+    method: 'GET',
+    dataType: 'json',
+    success: function (data) {
+      renderReport(data)
+    },
+    error: function (xhr) {
+      if (xhr.status === 404) {
+        $('#no-report-case').text(caseNum)
+        $('#no-report').removeClass('d-none')
+      } else if (xhr.status === 502 || xhr.status === 504) {
+        showAlert('AI Agents service is unreachable. Is it running?', 'warning')
+      } else {
+        showAlert('Error fetching report: ' + (xhr.responseJSON ? xhr.responseJSON.detail || xhr.responseJSON.error : xhr.statusText), 'danger')
+      }
+    }
+  })
+}
+
+function renderReport (data) {
+  currentAnalysisId = data.id
+  var report = data.full_report || {}
+
+  var statusBadge = $('#report-status-badge')
+  statusBadge.text(data.status || 'unknown')
+  statusBadge.attr('class', 'badge ' + statusBadgeClass(data.status))
+
+  var confidence = (report.analysis || {}).confidence || 'unknown'
+  var confBadge = $('#report-confidence-badge')
+  confBadge.text('Confidence: ' + confidence)
+  confBadge.attr('class', 'badge ' + confidenceBadgeClass(confidence))
+
+  var meta = 'Case ' + data.case_number
+  if (data.timestamp) meta += ' | ' + new Date(data.timestamp).toLocaleString()
+  if (data.model_id) meta += ' | ' + data.model_id
+  if (data.rounds_executed) meta += ' | ' + data.rounds_executed + ' round(s)'
+  $('#report-meta').text(meta)
+
+  $('#hypothesis-body').text((report.analysis || {}).root_cause_hypothesis || 'N/A')
+
+  renderDomainTags(report)
+  renderRecommendations(report)
+  renderSimilarCases(report)
+  renderJiras(report)
+  renderKB(report)
+  renderQuestions(report)
+  renderAgentSummaries(report)
+  renderDegraded(report)
+  renderWarnings(report)
+  renderAttachments(report)
+
+  $('#raw-json').text(JSON.stringify(data, null, 2))
+
+  showingRaw = false
+  $('#structured-view').removeClass('d-none')
+  $('#raw-view').addClass('d-none')
+  $('#toggle-view-btn').text('Raw JSON')
+
+  $('#report-container').removeClass('d-none')
+  $('#no-report').addClass('d-none')
+  $('#analysis-progress').addClass('d-none')
+
+  $('#feedback-status').text('')
+  $('#feedback-up').prop('disabled', false).removeClass('btn-success').addClass('btn-outline-success')
+  $('#feedback-down').prop('disabled', false).removeClass('btn-danger').addClass('btn-outline-danger')
+
+  loadThinkingLog()
+}
+
+function renderDomainTags (report) {
+  var tags = ((report.analysis || {}).domain_tags || [])
+  if (tags.length === 0) {
+    $('#domain-tags-card').addClass('d-none')
+    return
+  }
+  $('#domain-tags-card').removeClass('d-none')
+  var html = tags.map(function (t) {
+    return '<span class="badge bg-secondary me-1">' + escapeHtml(t) + '</span>'
+  }).join('')
+  $('#domain-tags-body').html(html)
+}
+
+function renderRecommendations (report) {
+  var recs = report.recommendations || []
+  if (recs.length === 0) { $('#recommendations-card').addClass('d-none'); return }
+  $('#recommendations-card').removeClass('d-none')
+  var html = recs.map(function (r) {
+    return '<tr><td>' + escapeHtml(r.action) + '</td>' +
+      '<td><code>' + escapeHtml(r.command || '') + '</code></td>' +
+      '<td><span class="badge ' + riskBadgeClass(r.risk) + '">' + escapeHtml(r.risk || 'safe') + '</span></td></tr>'
+  }).join('')
+  $('#recommendations-tbody').html(html)
+}
+
+function renderSimilarCases (report) {
+  var cases = report.similar_cases || []
+  if (cases.length === 0) { $('#similar-cases-card').addClass('d-none'); return }
+  $('#similar-cases-card').removeClass('d-none')
+  var html = cases.map(function (c) {
+    return '<tr><td>' + escapeHtml(c.case_number) + '</td>' +
+      '<td>' + (c.similarity ? (c.similarity * 100).toFixed(0) + '%' : '') + '</td>' +
+      '<td><span class="badge ' + relevanceBadgeClass(c.relevance) + '">' + escapeHtml(c.relevance || '') + '</span></td>' +
+      '<td>' + escapeHtml(c.resolution_summary || c.applicability || '') + '</td></tr>'
+  }).join('')
+  $('#similar-cases-tbody').html(html)
+}
+
+function renderJiras (report) {
+  var jiras = report.engineering_jiras || []
+  if (jiras.length === 0) { $('#jiras-card').addClass('d-none'); return }
+  $('#jiras-card').removeClass('d-none')
+  var html = jiras.map(function (j) {
+    var keyHtml = j.url
+      ? '<a href="' + escapeHtml(j.url) + '" target="_blank">' + escapeHtml(j.key) + '</a>'
+      : escapeHtml(j.key)
+    return '<tr><td>' + keyHtml + '</td>' +
+      '<td>' + escapeHtml(j.summary) + '</td>' +
+      '<td>' + escapeHtml(j.status) + '</td>' +
+      '<td>' + escapeHtml(j.priority) + '</td>' +
+      '<td>' + escapeHtml((j.fix_versions || []).join(', ')) + '</td></tr>'
+  }).join('')
+  $('#jiras-tbody').html(html)
+}
+
+function renderKB (report) {
+  var refs = report.kb_references || []
+  if (refs.length === 0) { $('#kb-card').addClass('d-none'); return }
+  $('#kb-card').removeClass('d-none')
+  var html = refs.map(function (r) {
+    var titleHtml = r.url
+      ? '<a href="' + escapeHtml(r.url) + '" target="_blank">' + escapeHtml(r.title) + '</a>'
+      : escapeHtml(r.title)
+    return '<tr><td>' + titleHtml + '</td>' +
+      '<td>' + escapeHtml(r.doc_type || '') + '</td>' +
+      '<td><small>' + escapeHtml(r.snippet || '') + '</small></td></tr>'
+  }).join('')
+  $('#kb-tbody').html(html)
+}
+
+function renderQuestions (report) {
+  var qs = report.clarifying_questions || []
+  if (qs.length === 0) { $('#questions-card').addClass('d-none'); return }
+  $('#questions-card').removeClass('d-none')
+  var html = qs.map(function (q) { return '<li>' + escapeHtml(q) + '</li>' }).join('')
+  $('#questions-list').html(html)
+}
+
+function renderAgentSummaries (report) {
+  var summaries = report.agent_summaries || {}
+  var agents = report.agents_consulted || []
+  if (agents.length === 0 && Object.keys(summaries).length === 0) {
+    $('#agents-card').addClass('d-none')
+    return
+  }
+  $('#agents-card').removeClass('d-none')
+  var html = ''
+  var keys = Object.keys(summaries).length > 0 ? Object.keys(summaries) : agents
+  keys.forEach(function (name) {
+    var s = summaries[name] || {}
+    html += '<div class="mb-2"><strong>' + escapeHtml(name) + '</strong>'
+    if (s.status) html += ' <span class="badge bg-secondary">' + escapeHtml(s.status) + '</span>'
+    if (s.confidence) html += ' <span class="badge bg-info">' + (s.confidence * 100).toFixed(0) + '%</span>'
+    if (s.key_finding) html += '<br><small>' + escapeHtml(s.key_finding) + '</small>'
+    html += '</div>'
+  })
+  $('#agents-body').html(html)
+}
+
+function renderDegraded (report) {
+  var steps = report.degraded_steps || []
+  if (steps.length === 0) { $('#degraded-card').addClass('d-none'); return }
+  $('#degraded-card').removeClass('d-none')
+  var html = steps.map(function (d) {
+    return '<tr><td>' + escapeHtml(d.step) + '</td>' +
+      '<td>' + escapeHtml(d.reason) + '</td>' +
+      '<td>' + escapeHtml(d.impact) + '</td></tr>'
+  }).join('')
+  $('#degraded-tbody').html(html)
+}
+
+function renderWarnings (report) {
+  var warns = report.context_warnings || []
+  if (warns.length === 0) { $('#warnings-card').addClass('d-none'); return }
+  $('#warnings-card').removeClass('d-none')
+  var html = warns.map(function (w) { return '<li>' + escapeHtml(w) + '</li>' }).join('')
+  $('#warnings-list').html(html)
+}
+
+function renderAttachments (report) {
+  var atts = report.attachments_reviewed || []
+  if (atts.length === 0) { $('#attachments-card').addClass('d-none'); return }
+  $('#attachments-card').removeClass('d-none')
+  var html = atts.map(function (a) {
+    return '<tr><td>' + escapeHtml(a.file_name) + '</td>' +
+      '<td>' + escapeHtml(a.file_type || '') + '</td>' +
+      '<td>' + (a.size_kb || '') + '</td>' +
+      '<td>' + escapeHtml(a.status || '') + '</td></tr>'
+  }).join('')
+  $('#attachments-tbody').html(html)
+}
+
+function toggleView () {
+  showingRaw = !showingRaw
+  if (showingRaw) {
+    $('#structured-view').addClass('d-none')
+    $('#raw-view').removeClass('d-none')
+    $('#toggle-view-btn').text('Structured View')
+  } else {
+    $('#structured-view').removeClass('d-none')
+    $('#raw-view').addClass('d-none')
+    $('#toggle-view-btn').text('Raw JSON')
+  }
+}
+
+function triggerAnalysis (force) {
+  if (!currentCaseNumber) return
+  hideAlert()
+  $('#no-report').addClass('d-none')
+  $('#report-container').addClass('d-none')
+  $('#analysis-progress').removeClass('d-none')
+  $('#analysis-status-text').text('Queuing analysis...')
+
+  var url = '/api/ai/analyze/' + encodeURIComponent(currentCaseNumber)
+  if (force) url += '?force=true'
+
+  $.ajax({
+    url: url,
+    method: 'POST',
+    dataType: 'json',
+    success: function (data) {
+      if (data.task_id) {
+        $('#analysis-status-text').text('Task queued. Polling for completion...')
+        pollStatus(data.task_id)
+      }
+    },
+    error: function (xhr) {
+      $('#analysis-progress').addClass('d-none')
+      if (xhr.status === 502 || xhr.status === 504) {
+        showAlert('AI Agents service is unreachable. Is it running?', 'warning')
+      } else {
+        showAlert('Failed to start analysis: ' + (xhr.responseJSON ? xhr.responseJSON.detail || xhr.responseJSON.error : xhr.statusText), 'danger')
+      }
+    }
+  })
+}
+
+function pollStatus (taskId) {
+  $.ajax({
+    url: '/api/ai/status/' + encodeURIComponent(taskId),
+    method: 'GET',
+    dataType: 'json',
+    success: function (data) {
+      $('#analysis-status-text').text('State: ' + data.state)
+      if (data.state === 'SUCCESS') {
+        $('#analysis-progress').addClass('d-none')
+        searchCase()
+      } else if (data.state === 'FAILURE') {
+        $('#analysis-progress').addClass('d-none')
+        showAlert('Analysis failed: ' + (data.error || 'Unknown error'), 'danger')
+      } else {
+        setTimeout(function () { pollStatus(taskId) }, 3000)
+      }
+    },
+    error: function () {
+      setTimeout(function () { pollStatus(taskId) }, 5000)
+    }
+  })
+}
+
+function loadThinkingLog () {
+  if (!currentAnalysisId) return
+  $('#thinking-log-tbody').html('<tr><td colspan="5" class="text-center">Loading...</td></tr>')
+
+  $.ajax({
+    url: '/api/ai/logs/' + encodeURIComponent(currentAnalysisId),
+    method: 'GET',
+    dataType: 'json',
+    success: function (logs) {
+      if (!logs || logs.length === 0) {
+        $('#thinking-log-tbody').html('<tr><td colspan="5" class="text-muted text-center">No log entries</td></tr>')
+        return
+      }
+      var html = logs.map(function (l) {
+        var round = l.round !== undefined ? l.round : (l.step_number !== undefined ? l.step_number : '')
+        return '<tr><td>' + round + '</td>' +
+          '<td>' + escapeHtml(l.agent_name || '') + '</td>' +
+          '<td><span class="badge bg-secondary">' + escapeHtml(l.action_type || '') + '</span></td>' +
+          '<td><small>' + escapeHtml(l.detail || '') + '</small></td>' +
+          '<td>' + (l.duration_ms != null ? l.duration_ms + 'ms' : '') + '</td></tr>'
+      }).join('')
+      $('#thinking-log-tbody').html(html)
+    },
+    error: function () {
+      $('#thinking-log-tbody').html('<tr><td colspan="5" class="text-muted text-center">Could not load thinking log</td></tr>')
+    }
+  })
+}
+
+function submitFeedback (vote) {
+  if (!currentAnalysisId) return
+
+  $.ajax({
+    url: '/api/ai/feedback/' + encodeURIComponent(currentAnalysisId),
+    method: 'POST',
+    contentType: 'application/json',
+    data: JSON.stringify({ vote: vote }),
+    dataType: 'json',
+    success: function () {
+      $('#feedback-status').text('Feedback submitted!')
+      if (vote === 'up') {
+        $('#feedback-up').removeClass('btn-outline-success').addClass('btn-success')
+      } else {
+        $('#feedback-down').removeClass('btn-outline-danger').addClass('btn-danger')
+      }
+      $('#feedback-up').prop('disabled', true)
+      $('#feedback-down').prop('disabled', true)
+    },
+    error: function () {
+      $('#feedback-status').text('Failed to submit feedback')
+    }
+  })
+}
+
+function statusBadgeClass (status) {
+  if (status === 'complete') return 'bg-success'
+  if (status === 'partial') return 'bg-warning text-dark'
+  if (status === 'failed') return 'bg-danger'
+  return 'bg-secondary'
+}
+
+function confidenceBadgeClass (confidence) {
+  if (confidence === 'high') return 'bg-success'
+  if (confidence === 'medium') return 'bg-warning text-dark'
+  if (confidence === 'low') return 'bg-danger'
+  return 'bg-secondary'
+}
+
+function riskBadgeClass (risk) {
+  if (risk === 'safe') return 'bg-success'
+  if (risk === 'write') return 'bg-warning text-dark'
+  if (risk === 'destructive') return 'bg-danger'
+  return 'bg-secondary'
+}
+
+function relevanceBadgeClass (relevance) {
+  if (relevance === 'high') return 'bg-success'
+  if (relevance === 'medium') return 'bg-warning text-dark'
+  if (relevance === 'low') return 'bg-info'
+  return 'bg-secondary'
+}
+
+function escapeHtml (str) {
+  if (!str) return ''
+  var div = document.createElement('div')
+  div.appendChild(document.createTextNode(str))
+  return div.innerHTML
+}

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -1,4 +1,4 @@
-/* global $, sessionStorage */
+/* global $, sessionStorage */ // eslint-disable-line no-redeclare
 
 let currentAnalysisId = null
 let currentCaseNumber = null

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -14,6 +14,9 @@ $(document).ready(function () {
   $('#run-analysis-btn').click(function () { triggerAnalysis(false) })
   $('#feedback-up').click(function () { submitFeedback('up') })
   $('#feedback-down').click(function () { submitFeedback('down') })
+
+  // Check for ongoing analysis from previous session
+  resumeOngoingAnalysis()
 })
 
 function showAlert (msg, type) {
@@ -75,7 +78,7 @@ function renderReport (data) {
   if (data.rounds_executed) meta += ' | ' + data.rounds_executed + ' round(s)'
   $('#report-meta').text(meta)
 
-  $('#hypothesis-body').text((report.analysis || {}).root_cause_hypothesis || 'N/A')
+  $('#hypothesis-body').html(markdownToHtml((report.analysis || {}).root_cause_hypothesis || 'N/A'))
 
   renderDomainTags(report)
   renderRecommendations(report)
@@ -124,7 +127,7 @@ function renderRecommendations (report) {
   if (recs.length === 0) { $('#recommendations-card').addClass('d-none'); return }
   $('#recommendations-card').removeClass('d-none')
   var html = recs.map(function (r) {
-    return '<tr><td>' + escapeHtml(r.action) + '</td>' +
+    return '<tr><td>' + markdownToHtml(r.action) + '</td>' +
       '<td><code>' + escapeHtml(r.command || '') + '</code></td>' +
       '<td><span class="badge ' + riskBadgeClass(r.risk) + '">' + escapeHtml(r.risk || 'safe') + '</span></td></tr>'
   }).join('')
@@ -136,10 +139,11 @@ function renderSimilarCases (report) {
   if (cases.length === 0) { $('#similar-cases-card').addClass('d-none'); return }
   $('#similar-cases-card').removeClass('d-none')
   var html = cases.map(function (c) {
-    return '<tr><td>' + escapeHtml(c.case_number) + '</td>' +
+    var caseLink = '<a href="https://access.redhat.com/support/cases/' + escapeHtml(c.case_number) + '" target="_blank">' + escapeHtml(c.case_number) + '</a>'
+    return '<tr><td>' + caseLink + '</td>' +
       '<td>' + (c.similarity ? (c.similarity * 100).toFixed(0) + '%' : '') + '</td>' +
       '<td><span class="badge ' + relevanceBadgeClass(c.relevance) + '">' + escapeHtml(c.relevance || '') + '</span></td>' +
-      '<td>' + escapeHtml(c.resolution_summary || c.applicability || '') + '</td></tr>'
+      '<td>' + markdownToHtml(c.resolution_summary || c.applicability || '') + '</td></tr>'
   }).join('')
   $('#similar-cases-tbody').html(html)
 }
@@ -269,6 +273,12 @@ function triggerAnalysis (force) {
     success: function (data) {
       if (data.task_id) {
         $('#analysis-status-text').text('Task queued. Polling for completion...')
+        // Save to sessionStorage for resume on page reload
+        sessionStorage.setItem('activeAnalysis', JSON.stringify({
+          task_id: data.task_id,
+          case_number: currentCaseNumber,
+          started_at: Date.now()
+        }))
         pollStatus(data.task_id)
       }
     },
@@ -289,26 +299,42 @@ function pollStatus (taskId) {
     method: 'GET',
     dataType: 'json',
     success: function (data) {
-      $('#analysis-status-text').text('State: ' + data.state)
+      var statusText = 'State: ' + data.state
+      if (data.state === 'PENDING') {
+        statusText = 'Queued, waiting for worker...'
+      } else if (data.state === 'STARTED') {
+        statusText = 'Running AI analysis (this takes 2-4 minutes)...'
+      }
+      $('#analysis-status-text').text(statusText)
+
       if (data.state === 'SUCCESS') {
+        sessionStorage.removeItem('activeAnalysis') // Clear on success
         $('#analysis-progress').addClass('d-none')
         searchCase()
       } else if (data.state === 'FAILURE') {
+        sessionStorage.removeItem('activeAnalysis') // Clear on failure
         $('#analysis-progress').addClass('d-none')
         showAlert('Analysis failed: ' + (data.error || 'Unknown error'), 'danger')
       } else {
         setTimeout(function () { pollStatus(taskId) }, 3000)
       }
     },
-    error: function () {
-      setTimeout(function () { pollStatus(taskId) }, 5000)
+    error: function (xhr) {
+      // If task not found (404), clear storage - task expired
+      if (xhr.status === 404) {
+        sessionStorage.removeItem('activeAnalysis')
+        $('#analysis-progress').addClass('d-none')
+        showAlert('Analysis task expired. Please run a new analysis.', 'warning')
+      } else {
+        setTimeout(function () { pollStatus(taskId) }, 5000)
+      }
     }
   })
 }
 
 function loadThinkingLog () {
   if (!currentAnalysisId) return
-  $('#thinking-log-tbody').html('<tr><td colspan="5" class="text-center">Loading...</td></tr>')
+  $('#thinking-log-tbody').html('<tr><td colspan="7" class="text-center">Loading...</td></tr>')
 
   $.ajax({
     url: '/api/ai/logs/' + encodeURIComponent(currentAnalysisId),
@@ -316,23 +342,35 @@ function loadThinkingLog () {
     dataType: 'json',
     success: function (logs) {
       if (!logs || logs.length === 0) {
-        $('#thinking-log-tbody').html('<tr><td colspan="5" class="text-muted text-center">No log entries</td></tr>')
+        $('#thinking-log-tbody').html('<tr><td colspan="7" class="text-muted text-center">No log entries</td></tr>')
         return
       }
       var html = logs.map(function (l) {
         var round = l.round !== undefined ? l.round : (l.step_number !== undefined ? l.step_number : '')
+        var tokensIn = l.input_tokens != null ? formatNumber(l.input_tokens) : ''
+        var tokensOut = l.output_tokens != null ? formatNumber(l.output_tokens) : ''
+        var tokensInClass = l.input_tokens != null ? '' : 'text-muted'
+        var tokensOutClass = l.output_tokens != null ? '' : 'text-muted'
+
         return '<tr><td>' + round + '</td>' +
           '<td>' + escapeHtml(l.agent_name || '') + '</td>' +
           '<td><span class="badge bg-secondary">' + escapeHtml(l.action_type || '') + '</span></td>' +
           '<td><small>' + escapeHtml(l.detail || '') + '</small></td>' +
-          '<td>' + (l.duration_ms != null ? l.duration_ms + 'ms' : '') + '</td></tr>'
+          '<td>' + (l.duration_ms != null ? l.duration_ms + 'ms' : '') + '</td>' +
+          '<td class="' + tokensInClass + '">' + tokensIn + '</td>' +
+          '<td class="' + tokensOutClass + '">' + tokensOut + '</td></tr>'
       }).join('')
       $('#thinking-log-tbody').html(html)
     },
     error: function () {
-      $('#thinking-log-tbody').html('<tr><td colspan="5" class="text-muted text-center">Could not load thinking log</td></tr>')
+      $('#thinking-log-tbody').html('<tr><td colspan="7" class="text-muted text-center">Could not load thinking log</td></tr>')
     }
   })
+}
+
+function formatNumber (num) {
+  if (num == null) return ''
+  return num.toLocaleString()
 }
 
 function submitFeedback (vote) {
@@ -358,6 +396,36 @@ function submitFeedback (vote) {
       $('#feedback-status').text('Failed to submit feedback')
     }
   })
+}
+
+function resumeOngoingAnalysis () {
+  var stored = sessionStorage.getItem('activeAnalysis')
+  if (!stored) return
+
+  try {
+    var data = JSON.parse(stored)
+    var ageHours = (Date.now() - data.started_at) / (1000 * 60 * 60)
+
+    // Ignore if older than 2 hours (likely expired)
+    if (ageHours > 2) {
+      sessionStorage.removeItem('activeAnalysis')
+      return
+    }
+
+    // Resume the analysis
+    currentCaseNumber = data.case_number
+    $('#case-number-input').val(data.case_number)
+    $('#no-report').addClass('d-none')
+    $('#report-container').addClass('d-none')
+    $('#analysis-progress').removeClass('d-none')
+    $('#analysis-status-text').text('Resuming analysis...')
+
+    // Start polling
+    pollStatus(data.task_id)
+  } catch (e) {
+    // Invalid JSON, clear it
+    sessionStorage.removeItem('activeAnalysis')
+  }
 }
 
 function statusBadgeClass (status) {
@@ -393,4 +461,32 @@ function escapeHtml (str) {
   var div = document.createElement('div')
   div.appendChild(document.createTextNode(str))
   return div.innerHTML
+}
+
+function markdownToHtml (markdown) {
+  if (!markdown) return ''
+
+  // Escape HTML first
+  var html = escapeHtml(markdown)
+
+  // Convert markdown to HTML
+  // Bold **text**
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  // Italic *text*
+  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>')
+  // Code `code`
+  html = html.replace(/`(.+?)`/g, '<code>$1</code>')
+  // Line breaks
+  html = html.replace(/\n/g, '<br>')
+
+  // Headers
+  html = html.replace(/^### (.+)$/gm, '<h5>$1</h5>')
+  html = html.replace(/^## (.+)$/gm, '<h4>$1</h4>')
+  html = html.replace(/^# (.+)$/gm, '<h3>$1</h3>')
+
+  // Bullet lists (simple version)
+  html = html.replace(/^- (.+)$/gm, '<li>$1</li>')
+  html = html.replace(/(<li>.*<\/li>)/s, '<ul>$1</ul>')
+
+  return html
 }

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -92,8 +92,7 @@ function renderReport (data) {
   renderDegraded(report)
   renderWarnings(report)
   renderAttachments(report)
-  renderMgValidation(data.must_gather_validation)
-  renderSosValidation(data.sos_report_validation)
+  renderValidation(data.must_gather_validation, data.sos_report_validation)
 
   $('#raw-json').text(JSON.stringify(data, null, 2))
 
@@ -246,83 +245,104 @@ function renderAttachments (report) {
   $('#attachments-tbody').html(html)
 }
 
-function renderValidationCard (validation, cardId, bodyId, cmdLabel) {
-  if (!validation || !validation.validated) {
-    $(cardId).addClass('d-none')
+function renderValidation (mgValidation, sosValidation) {
+  var mgActive = mgValidation && mgValidation.validated
+  var sosActive = sosValidation && sosValidation.validated
+
+  if (!mgActive && !sosActive) {
+    $('#validation-card').addClass('d-none')
     return
   }
-  $(cardId).removeClass('d-none')
+  $('#validation-card').removeClass('d-none')
 
+  var primary = mgActive ? mgValidation : sosValidation
   var decisionClass = 'bg-secondary'
-  if (validation.decision === 'confirmed') decisionClass = 'bg-success'
-  else if (validation.decision === 'refuted') decisionClass = 'bg-danger'
-  else if (validation.decision === 'inconclusive') decisionClass = 'bg-warning text-dark'
+  if (primary.decision === 'confirmed') decisionClass = 'bg-success'
+  else if (primary.decision === 'refuted') decisionClass = 'bg-danger'
+  else if (primary.decision === 'inconclusive') decisionClass = 'bg-warning text-dark'
 
   var html = '<div class="mb-3">'
-  html += '<span class="badge ' + decisionClass + ' me-2">' + escapeHtml(validation.decision) + '</span>'
-  if (validation.confidence != null) {
-    html += '<span class="badge bg-info me-2">Confidence: ' + (validation.confidence * 100).toFixed(0) + '%</span>'
+  html += '<span class="badge ' + decisionClass + ' me-2">' + escapeHtml(primary.decision) + '</span>'
+  if (primary.confidence != null) {
+    html += '<span class="badge bg-info me-2">Confidence: ' + (primary.confidence * 100).toFixed(0) + '%</span>'
   }
-  if (validation.round) {
-    html += '<span class="badge bg-secondary">Round ' + validation.round + '</span>'
+  if (primary.round) {
+    html += '<span class="badge bg-secondary">Round ' + primary.round + '</span>'
   }
   html += '</div>'
 
-  if (validation.reasoning) {
-    html += '<p>' + markdownToHtml(validation.reasoning) + '</p>'
+  if (primary.reasoning) {
+    html += '<p>' + markdownToHtml(primary.reasoning) + '</p>'
   }
 
-  if (validation.filename) {
-    html += '<p class="text-muted mb-2"><small>Archive: ' + escapeHtml(validation.filename)
-    if (validation.size_mb) html += ' (' + validation.size_mb.toFixed(1) + ' MB)'
-    html += '</small></p>'
-  }
+  var cmdIndex = 0
 
-  var cmds = validation.commands_executed || []
-  if (cmds.length > 0) {
-    html += '<div class="accordion" id="' + bodyId + '-accordion">'
-    cmds.forEach(function (cmd, idx) {
-      var statusIcon = '?'
-      var statusClass = 'text-secondary'
-      if (cmd.status === 'success') { statusIcon = '✓'; statusClass = 'text-success' }
-      else if (cmd.status === 'empty') { statusIcon = '○'; statusClass = 'text-muted' }
-      else if (cmd.status === 'timeout') { statusIcon = '⏱'; statusClass = 'text-warning' }
-      else if (cmd.status === 'error' || cmd.status === 'omc_error') { statusIcon = '✗'; statusClass = 'text-danger' }
-
-      var cmdText = cmd.command || cmd.original_command || 'N/A'
-      var collapseId = bodyId + '-cmd-' + idx
-
-      html += '<div class="accordion-item">'
-      html += '<h2 class="accordion-header">'
-      html += '<button class="accordion-button collapsed py-2" type="button" data-bs-toggle="collapse" data-bs-target="#' + collapseId + '">'
-      html += '<span class="' + statusClass + ' me-2">' + statusIcon + '</span> '
-      html += '<code class="me-2">' + escapeHtml(cmdText) + '</code> '
-      if (cmd.duration_ms) html += '<small class="text-muted">' + cmd.duration_ms + 'ms</small>'
-      html += '</button></h2>'
-      html += '<div id="' + collapseId + '" class="accordion-collapse collapse">'
-      html += '<div class="accordion-body">'
-      if (cmd.stdout) {
-        html += '<pre class="bg-light p-2 border rounded" style="max-height:300px;overflow:auto;font-size:0.85em">' + escapeHtml(cmd.stdout) + '</pre>'
-      } else {
-        html += '<p class="text-muted">(no output)</p>'
+  if (mgActive) {
+    var mgCmds = mgValidation.commands_executed || []
+    if (mgCmds.length > 0) {
+      html += '<h6 class="mt-3">Must-Gather Commands'
+      if (mgValidation.filename) {
+        html += ' <small class="text-muted">(' + escapeHtml(mgValidation.filename)
+        if (mgValidation.size_mb) html += ', ' + mgValidation.size_mb.toFixed(1) + ' MB'
+        html += ')</small>'
       }
-      if (cmd.stderr) {
-        html += '<pre class="bg-light p-2 border rounded text-danger" style="max-height:150px;overflow:auto;font-size:0.85em">' + escapeHtml(cmd.stderr) + '</pre>'
-      }
-      html += '</div></div></div>'
-    })
-    html += '</div>'
+      html += '</h6>'
+      html += _renderCommandAccordion(mgCmds, 'mg', cmdIndex)
+      cmdIndex += mgCmds.length
+    }
   }
 
-  $(bodyId).html(html)
+  if (sosActive) {
+    var sosCmds = sosValidation.commands_executed || []
+    if (sosCmds.length > 0) {
+      html += '<h6 class="mt-3">Sos-Report Commands'
+      if (sosValidation.filename) {
+        html += ' <small class="text-muted">(' + escapeHtml(sosValidation.filename)
+        if (sosValidation.size_mb) html += ', ' + sosValidation.size_mb.toFixed(1) + ' MB'
+        html += ')</small>'
+      }
+      html += '</h6>'
+      html += _renderCommandAccordion(sosCmds, 'sos', cmdIndex)
+    }
+  }
+
+  $('#validation-body').html(html)
 }
 
-function renderMgValidation (validation) {
-  renderValidationCard(validation, '#mg-validation-card', '#mg-validation-body', 'OMC')
-}
+function _renderCommandAccordion (cmds, prefix, startIdx) {
+  var html = '<div class="accordion mb-2" id="val-' + prefix + '-accordion">'
+  cmds.forEach(function (cmd, idx) {
+    var statusIcon = '?'
+    var statusClass = 'text-secondary'
+    if (cmd.status === 'success') { statusIcon = '✓'; statusClass = 'text-success' }
+    else if (cmd.status === 'empty') { statusIcon = '○'; statusClass = 'text-muted' }
+    else if (cmd.status === 'timeout') { statusIcon = '⏱'; statusClass = 'text-warning' }
+    else if (cmd.status === 'error' || cmd.status === 'omc_error') { statusIcon = '✗'; statusClass = 'text-danger' }
 
-function renderSosValidation (validation) {
-  renderValidationCard(validation, '#sos-validation-card', '#sos-validation-body', 'Command')
+    var cmdText = cmd.command || cmd.original_command || 'N/A'
+    var collapseId = 'val-' + prefix + '-cmd-' + (startIdx + idx)
+
+    html += '<div class="accordion-item">'
+    html += '<h2 class="accordion-header">'
+    html += '<button class="accordion-button collapsed py-2" type="button" data-bs-toggle="collapse" data-bs-target="#' + collapseId + '">'
+    html += '<span class="' + statusClass + ' me-2">' + statusIcon + '</span> '
+    html += '<code class="me-2">' + escapeHtml(cmdText) + '</code> '
+    if (cmd.duration_ms) html += '<small class="text-muted">' + cmd.duration_ms + 'ms</small>'
+    html += '</button></h2>'
+    html += '<div id="' + collapseId + '" class="accordion-collapse collapse">'
+    html += '<div class="accordion-body">'
+    if (cmd.stdout) {
+      html += '<pre class="bg-light p-2 border rounded" style="max-height:300px;overflow:auto;font-size:0.85em">' + escapeHtml(cmd.stdout) + '</pre>'
+    } else {
+      html += '<p class="text-muted">(no output)</p>'
+    }
+    if (cmd.stderr) {
+      html += '<pre class="bg-light p-2 border rounded text-danger" style="max-height:150px;overflow:auto;font-size:0.85em">' + escapeHtml(cmd.stderr) + '</pre>'
+    }
+    html += '</div></div></div>'
+  })
+  html += '</div>'
+  return html
 }
 
 function toggleView () {

--- a/dashboard/src/t5gweb/static/js/agent.js
+++ b/dashboard/src/t5gweb/static/js/agent.js
@@ -1,4 +1,4 @@
-/* global $ */
+/* global $, sessionStorage */
 
 let currentAnalysisId = null
 let currentCaseNumber = null
@@ -314,10 +314,15 @@ function _renderCommandAccordion (cmds, prefix, startIdx) {
   cmds.forEach(function (cmd, idx) {
     let statusIcon = '?'
     let statusClass = 'text-secondary'
-    if (cmd.status === 'success') { statusIcon = '✓'; statusClass = 'text-success' }
-    else if (cmd.status === 'empty') { statusIcon = '○'; statusClass = 'text-muted' }
-    else if (cmd.status === 'timeout') { statusIcon = '⏱'; statusClass = 'text-warning' }
-    else if (cmd.status === 'error' || cmd.status === 'omc_error') { statusIcon = '✗'; statusClass = 'text-danger' }
+    if (cmd.status === 'success') {
+      statusIcon = '✓'; statusClass = 'text-success'
+    } else if (cmd.status === 'empty') {
+      statusIcon = '○'; statusClass = 'text-muted'
+    } else if (cmd.status === 'timeout') {
+      statusIcon = '⏱'; statusClass = 'text-warning'
+    } else if (cmd.status === 'error' || cmd.status === 'omc_error') {
+      statusIcon = '✗'; statusClass = 'text-danger'
+    }
 
     const cmdText = cmd.command || cmd.original_command || 'N/A'
     const collapseId = 'val-' + prefix + '-cmd-' + (startIdx + idx)

--- a/dashboard/src/t5gweb/static/style.css
+++ b/dashboard/src/t5gweb/static/style.css
@@ -226,3 +226,23 @@ span.anchor {
   color: black !important;
 }
 
+/* AI Agent view */
+#agent-search-bar {
+  max-width: 500px;
+}
+
+#raw-json {
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+#thinking-log-collapse .table td {
+  font-size: 0.85em;
+}
+
+#report-container .card-header {
+  font-size: 0.95em;
+  padding: 0.5rem 1rem;
+}
+

--- a/dashboard/src/t5gweb/static/style.css
+++ b/dashboard/src/t5gweb/static/style.css
@@ -234,7 +234,7 @@ span.anchor {
 #raw-json {
   font-size: 0.85em;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 #thinking-log-collapse .table td {

--- a/dashboard/src/t5gweb/templates/skeleton.html
+++ b/dashboard/src/t5gweb/templates/skeleton.html
@@ -85,6 +85,21 @@
                                 <a class="nav-link active" href="{{ url_for('ui.get_stats') }}">Stats</a>
                             </li>
                             <li class="nav-item ms-2">
+                                <a role="button" class="btn btn-dark" href="{{ url_for('ui.agent_view') }}" title="AI Agent">
+                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                         width="25"
+                                         height="25"
+                                         fill="currentColor"
+                                         role="img"
+                                         aria-label="AI Agent"
+                                         class="bi bi-robot"
+                                         viewBox="0 0 16 16">
+                                        <path d="M6 12.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5M3 8.062C3 6.76 4.235 5.765 5.53 5.886a26.6 26.6 0 0 0 4.94 0C11.765 5.765 13 6.76 13 8.062v1.157a.93.93 0 0 1-.765.935c-.845.147-2.34.346-4.235.346s-3.39-.2-4.235-.346A.93.93 0 0 1 3 9.219zm4.542-.827a.25.25 0 0 0-.217.068l-.92.9a25 25 0 0 1-1.871-.183.25.25 0 0 0-.068.495c.55.076 1.232.149 2.02.193a.25.25 0 0 0 .189-.071l.754-.736.847 1.71a.25.25 0 0 0 .404.062l.932-.97a25 25 0 0 0 1.922-.188.25.25 0 0 0-.068-.495c-.538.074-1.207.145-1.98.189a.25.25 0 0 0-.166.076l-.754.785-.842-1.7a.25.25 0 0 0-.182-.135"/>
+                                        <path d="M8.5 1.866a1 1 0 1 0-1 0V3h-2A4.5 4.5 0 0 0 1 7.5V8a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1v1a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-1a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1v-.5A4.5 4.5 0 0 0 10.5 3h-2zM14 7.5V13a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V7.5A3.5 3.5 0 0 1 5.5 4h5A3.5 3.5 0 0 1 14 7.5"/>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="nav-item ms-2">
                                 <a role="button" class="btn btn-dark" href="{{ url_for('ui.trends') }}">
                                     <svg xmlns="http://www.w3.org/2000/svg"
                                          width="25"

--- a/dashboard/src/t5gweb/templates/ui/agent.html
+++ b/dashboard/src/t5gweb/templates/ui/agent.html
@@ -171,14 +171,9 @@
                             </div>
                         </div>
 
-                        <div class="card mb-3" id="mg-validation-card">
-                            <div class="card-header"><strong>Must-Gather Validation</strong></div>
-                            <div class="card-body" id="mg-validation-body"></div>
-                        </div>
-
-                        <div class="card mb-3" id="sos-validation-card">
-                            <div class="card-header"><strong>Sos-Report Validation</strong></div>
-                            <div class="card-body" id="sos-validation-body"></div>
+                        <div class="card mb-3" id="validation-card">
+                            <div class="card-header"><strong>Hypothesis Validation</strong></div>
+                            <div class="card-body" id="validation-body"></div>
                         </div>
                     </div>
 

--- a/dashboard/src/t5gweb/templates/ui/agent.html
+++ b/dashboard/src/t5gweb/templates/ui/agent.html
@@ -1,0 +1,229 @@
+{% extends "skeleton.html" %}
+{% block title %}AI Agent{% endblock %}
+{% block content %}
+    <div class="container-fluid mt-5 pt-3">
+        <div class="row justify-content-center">
+            <div class="col-12 col-lg-10">
+                <h2>AI Case Analysis</h2>
+                <div class="input-group mb-3" id="agent-search-bar">
+                    <input type="text"
+                           class="form-control"
+                           id="case-number-input"
+                           placeholder="Enter case number (e.g. 03252981)"
+                           aria-label="Case number">
+                    <button class="btn btn-primary" type="button" id="search-btn">Search</button>
+                </div>
+
+                <div id="agent-alert" class="alert d-none" role="alert"></div>
+
+                <div id="analysis-progress" class="d-none mb-3">
+                    <div class="d-flex align-items-center">
+                        <strong>Analysis in progress...</strong>
+                        <div class="spinner-border ms-auto" role="status" aria-hidden="true"></div>
+                    </div>
+                    <div class="progress mt-2">
+                        <div class="progress-bar progress-bar-striped progress-bar-animated"
+                             role="progressbar" style="width: 100%"></div>
+                    </div>
+                    <small class="text-muted" id="analysis-status-text"></small>
+                </div>
+
+                <div id="report-container" class="d-none">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <div>
+                            <span class="badge" id="report-status-badge"></span>
+                            <span class="badge" id="report-confidence-badge"></span>
+                            <small class="text-muted ms-2" id="report-meta"></small>
+                        </div>
+                        <div>
+                            <button class="btn btn-sm btn-outline-secondary" id="toggle-view-btn">Raw JSON</button>
+                            <button class="btn btn-sm btn-outline-primary" id="reanalyze-btn" title="Force re-analysis">Re-analyze</button>
+                        </div>
+                    </div>
+
+                    <div id="structured-view">
+                        <div class="card mb-3">
+                            <div class="card-header"><strong>Root Cause Hypothesis</strong></div>
+                            <div class="card-body" id="hypothesis-body"></div>
+                        </div>
+
+                        <div class="card mb-3" id="domain-tags-card">
+                            <div class="card-header"><strong>Domain Tags</strong></div>
+                            <div class="card-body" id="domain-tags-body"></div>
+                        </div>
+
+                        <div class="card mb-3" id="recommendations-card">
+                            <div class="card-header"><strong>Recommendations</strong></div>
+                            <div class="card-body p-0">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Action</th>
+                                            <th>Command</th>
+                                            <th>Risk</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="recommendations-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="similar-cases-card">
+                            <div class="card-header"><strong>Similar Cases</strong></div>
+                            <div class="card-body p-0">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Case</th>
+                                            <th>Similarity</th>
+                                            <th>Relevance</th>
+                                            <th>Resolution</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="similar-cases-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="jiras-card">
+                            <div class="card-header"><strong>Engineering Jiras</strong></div>
+                            <div class="card-body p-0">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Key</th>
+                                            <th>Summary</th>
+                                            <th>Status</th>
+                                            <th>Priority</th>
+                                            <th>Fix Versions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="jiras-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="kb-card">
+                            <div class="card-header"><strong>KB References</strong></div>
+                            <div class="card-body p-0">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Title</th>
+                                            <th>Type</th>
+                                            <th>Snippet</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="kb-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="questions-card">
+                            <div class="card-header"><strong>Clarifying Questions</strong></div>
+                            <div class="card-body">
+                                <ul id="questions-list"></ul>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="agents-card">
+                            <div class="card-header"><strong>Agent Summaries</strong></div>
+                            <div class="card-body" id="agents-body"></div>
+                        </div>
+
+                        <div class="card mb-3" id="degraded-card">
+                            <div class="card-header"><strong>Degraded Steps</strong></div>
+                            <div class="card-body p-0">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Step</th>
+                                            <th>Reason</th>
+                                            <th>Impact</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="degraded-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="warnings-card">
+                            <div class="card-header"><strong>Context Warnings</strong></div>
+                            <div class="card-body">
+                                <ul id="warnings-list"></ul>
+                            </div>
+                        </div>
+
+                        <div class="card mb-3" id="attachments-card">
+                            <div class="card-header"><strong>Attachments Reviewed</strong></div>
+                            <div class="card-body p-0">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>File</th>
+                                            <th>Type</th>
+                                            <th>Size (KB)</th>
+                                            <th>Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="attachments-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="raw-view" class="d-none">
+                        <pre id="raw-json" class="bg-light p-3 border rounded" style="max-height: 600px; overflow: auto;"></pre>
+                    </div>
+
+                    <div class="mt-3 mb-3" id="thinking-log-section">
+                        <button class="btn btn-sm btn-outline-secondary" type="button"
+                                data-bs-toggle="collapse" data-bs-target="#thinking-log-collapse">
+                            Thinking Log
+                        </button>
+                        <div class="collapse mt-2" id="thinking-log-collapse">
+                            <div class="card card-body p-0">
+                                <table class="table table-sm table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Round</th>
+                                            <th>Agent</th>
+                                            <th>Action</th>
+                                            <th>Detail</th>
+                                            <th>Duration</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="thinking-log-tbody"></tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="d-flex align-items-center gap-2 mb-4" id="feedback-section">
+                        <span>Was this analysis helpful?</span>
+                        <button class="btn btn-sm btn-outline-success" id="feedback-up" title="Thumbs up">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                <path d="M6.956 1.745C7.021.81 7.908.087 8.864.325l.261.066c.463.116.874.456 1.012.965.22.816.533 2.511.062 4.51a10 10 0 0 1 .443-.051c.713-.065 1.669-.072 2.516.21.518.173.994.681 1.2 1.273.184.532.16 1.162-.234 1.733.058.119.103.242.138.363.077.27.113.567.113.856s-.036.586-.113.856c-.039.135-.09.273-.16.404.169.387.107.819-.003 1.148a3.2 3.2 0 0 1-.488.901c.054.152.076.312.076.465 0 .305-.089.625-.253.912C13.1 15.522 12.437 16 11.5 16H8c-.605 0-1.07-.081-1.466-.218a4.8 4.8 0 0 1-.97-.484l-.048-.03c-.504-.307-.999-.609-2.068-.722C2.682 14.464 2 13.846 2 13V9c0-.85.685-1.432 1.357-1.615.849-.232 1.574-.787 2.132-1.41.56-.627.914-1.28 1.039-1.639.199-.575.356-1.539.428-2.59z"/>
+                            </svg>
+                        </button>
+                        <button class="btn btn-sm btn-outline-danger" id="feedback-down" title="Thumbs down">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                <path d="M6.956 14.534c.065.936.952 1.659 1.908 1.42l.261-.065a1.38 1.38 0 0 0 1.012-.965c.22-.816.533-2.512.062-4.51q.205.03.443.051c.713.065 1.669.071 2.516-.211.518-.173.994-.68 1.2-1.272a1.9 1.9 0 0 0-.234-1.734c.058-.118.103-.242.138-.362.077-.27.113-.568.113-.856s-.036-.586-.113-.857a2 2 0 0 0-.16-.403c.169-.387.107-.82-.003-1.149a3.2 3.2 0 0 0-.488-.9c.054-.153.076-.313.076-.466a1.65 1.65 0 0 0-.253-.912C13.1.757 12.437.28 11.5.28H8c-.605 0-1.07.08-1.466.217a4.8 4.8 0 0 0-.97.485l-.048.029c-.504.308-.999.61-2.068.723C2.682 1.815 2 2.434 2 3.279v4c0 .851.685 1.433 1.357 1.616.849.232 1.574.787 2.132 1.41.56.626.914 1.28 1.039 1.638.199.575.356 1.54.428 2.591"/>
+                            </svg>
+                        </button>
+                        <span id="feedback-status" class="text-muted small"></span>
+                    </div>
+                </div>
+
+                <div id="no-report" class="d-none">
+                    <div class="alert alert-info">
+                        No AI analysis found for case <strong id="no-report-case"></strong>.
+                    </div>
+                    <button class="btn btn-primary" id="run-analysis-btn">Run Analysis</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript" charset="utf8"
+            src="{{ url_for('static', filename='js/agent.js') }}"></script>
+{% endblock %}

--- a/dashboard/src/t5gweb/templates/ui/agent.html
+++ b/dashboard/src/t5gweb/templates/ui/agent.html
@@ -191,6 +191,8 @@
                                             <th>Action</th>
                                             <th>Detail</th>
                                             <th>Duration</th>
+                                            <th>Tokens In</th>
+                                            <th>Tokens Out</th>
                                         </tr>
                                     </thead>
                                     <tbody id="thinking-log-tbody"></tbody>

--- a/dashboard/src/t5gweb/templates/ui/agent.html
+++ b/dashboard/src/t5gweb/templates/ui/agent.html
@@ -170,6 +170,16 @@
                                 </table>
                             </div>
                         </div>
+
+                        <div class="card mb-3" id="mg-validation-card">
+                            <div class="card-header"><strong>Must-Gather Validation</strong></div>
+                            <div class="card-body" id="mg-validation-body"></div>
+                        </div>
+
+                        <div class="card mb-3" id="sos-validation-card">
+                            <div class="card-header"><strong>Sos-Report Validation</strong></div>
+                            <div class="card-body" id="sos-validation-body"></div>
+                        </div>
                     </div>
 
                     <div id="raw-view" class="d-none">

--- a/dashboard/src/t5gweb/ui.py
+++ b/dashboard/src/t5gweb/ui.py
@@ -558,6 +558,12 @@ def get_stats():
     )
 
 
+@BP.route("/agent")
+@login_required
+def agent_view():
+    return render_template("ui/agent.html", timestamp=redis_get("timestamp"))
+
+
 @BP.route("/account/<string:account>")
 @login_required
 def get_account(account):


### PR DESCRIPTION
  ## Summary
  - Add a new AI Agent view (`/agent`) that lets users trigger and view AI-powered case analysis directly from the dashboard
  - Proxy API endpoints in Flask forward requests to an external AI Agents service (`AI_AGENTS_API_URL`), with timeout and connection error handling
  - Frontend includes case search, analysis polling with progress indicator, structured report rendering (hypothesis, recommendations, similar cases, Jiras, KBs), feedback submission,
  thinking log with token usage, and must-gather/sos-report validation cards

  ## Details
  - **Backend** (`api.py`, `ui.py`): 6 new `/api/ai/*` proxy routes (report, analyze, status, logs, feedback) with a shared `_ai_proxy` helper
  - **Frontend** (`agent.html`, `agent.js`, `style.css`): Full single-page view for interacting with AI analysis — search by case number, trigger/re-trigger analysis, poll for completion,
  render structured results, toggle raw JSON, and submit thumbs-up/down feedback
  - **Infra** (`docker-compose.yml`): Wires the `AI_AGENTS_API_URL` env var into the container
  - **UX polish**: Merged validation cards into a single Hypothesis Validation view, removed outdated duration estimates, added resilience to transient polling errors

  ## Status
  🚧 Work in progress (blocked by pro creds)
  
  ## Test plan
  - [x] Verify `/agent` page loads and case search works against a running AI Agents service
  - [x] Confirm analysis polling handles service-down (502) and timeout (504) gracefully
  - [x] Test re-analyze (force) flow
  - [x] Validate feedback submission (thumbs up/down)
  - [x] Check thinking log and token usage display
  - [x] Verify must-gather and sos-report validation cards render correctly
