### PR TITLE
fix: read only mode for sync priority

### DIFF
--- a/dashboard/src/t5gweb/libtelco5g.py
+++ b/dashboard/src/t5gweb/libtelco5g.py
@@ -1260,6 +1260,12 @@ def sync_priority(cfg):
         dict: Dictionary of out-of-sync cards that were updated, keyed by
             card key
     """
+    read_only = os.getenv("READ_ONLY", "false") == "true"
+
+    if read_only:
+        logging.warning("ReadOnly mode is active - skipping priority sync")
+        return {}
+
     cards = redis_get("cards")
     jira_conn = jira_connection(cfg)
 


### PR DESCRIPTION
I observed that severity changes were happening while ReadOnly mode was set to true.
This should fix it 